### PR TITLE
Jun9 update

### DIFF
--- a/cg_openmm/simulation/rep_exch.py
+++ b/cg_openmm/simulation/rep_exch.py
@@ -227,7 +227,7 @@ def run_replica_exchange(
         else:
             exchange_frequency = 10
 			
-	exchange_attempts = math.floor(simulation_steps/exchange_frequency)
+    exchange_attempts = math.floor(simulation_steps/exchange_frequency)
 
     if temperature_list is None:
         temperature_list = [

--- a/examples/replica_exchange/run_replica_exchange.py
+++ b/examples/replica_exchange/run_replica_exchange.py
@@ -36,7 +36,7 @@ number_replicas = 12
 min_temp = 600.0 * unit.kelvin
 max_temp = 1000.0 * unit.kelvin
 temperature_list = get_temperature_list(min_temp, max_temp, number_replicas)
-exchange_frequency = 50
+exchange_frequency = 50  # Number of steps between exchange attempts
 
 # Coarse grained model settings
 polymer_length = 12
@@ -137,6 +137,7 @@ if not os.path.exists(output_data) or overwrite_files == True:
         temperature_list=temperature_list,
         simulation_time_step=simulation_time_step,
         total_simulation_time=total_simulation_time,
+		exchange_frequency=exchange_frequency,
         print_frequency=print_frequency,
         output_data=output_data,
         output_directory=output_directory,

--- a/examples/replica_exchange/run_replica_exchange.py
+++ b/examples/replica_exchange/run_replica_exchange.py
@@ -137,7 +137,7 @@ if not os.path.exists(output_data) or overwrite_files == True:
         temperature_list=temperature_list,
         simulation_time_step=simulation_time_step,
         total_simulation_time=total_simulation_time,
-	exchange_frequency=exchange_frequency,
+        exchange_frequency=exchange_frequency,
         print_frequency=print_frequency,
         output_data=output_data,
         output_directory=output_directory,

--- a/examples/replica_exchange/run_replica_exchange.py
+++ b/examples/replica_exchange/run_replica_exchange.py
@@ -137,7 +137,7 @@ if not os.path.exists(output_data) or overwrite_files == True:
         temperature_list=temperature_list,
         simulation_time_step=simulation_time_step,
         total_simulation_time=total_simulation_time,
-		exchange_frequency=exchange_frequency,
+	exchange_frequency=exchange_frequency,
         print_frequency=print_frequency,
         output_data=output_data,
         output_directory=output_directory,


### PR DESCRIPTION
Made some changes to how we specify exchange frequency (number of time steps between exchange attempts) in the replica exchange input script:

- Exchange frequency is passed to run_replica_exchange, rather than exchange attempts (number of exchanges over entire simulation).
- Exchange attempts calculated internally within run_replica_exchange
- Updated default exchange frequency to 1000 (openmmtools default)