### PR TITLE
various changes to implement Rosetta functional form

### DIFF
--- a/cg_openmm/build/cg_build.py
+++ b/cg_openmm/build/cg_build.py
@@ -669,7 +669,7 @@ def add_force(cgmodel, force_type=None, rosetta_functional_form=False):
             # functional form as the Rosetta cutoff, but it should be somewhat close.
             nonbonded_force.setNonbondedMethod(mm.NonbondedForce.CutoffNonPeriodic)
             nonbonded_force.setCutoffDistance(0.6) # rosetta cutoff distance in nm
-            nonbonded_force.setUseSwitchingFunction()
+            nonbonded_force.setUseSwitchingFunction(True)
             nonbonded_force.setSwitchingDistance(0.45) # start of rosetta switching distance in nm
         else:
             nonbonded_force.setNonbondedMethod(mm.NonbondedForce.NoCutoff)
@@ -837,12 +837,6 @@ def build_system(cgmodel, rosetta_functional_form=False, verify=True):
         cgmodel, nonbonded_force = add_force(
             cgmodel, force_type="Nonbonded", rosetta_functional_form=rosetta_functional_form
         )
-
-        # if cgmodel.positions != None:
-        # print("Testing the nonbonded forces")
-        # if not test_force(cgmodel,nonbonded_force,force_type="Nonbonded"):
-        # print("ERROR: there was a problem with the nonbonded force definitions.")
-        # exit()
 
     if cgmodel.include_bond_forces or cgmodel.constrain_bonds:
         if len(cgmodel.bond_list) > 0:

--- a/cg_openmm/build/cg_build.py
+++ b/cg_openmm/build/cg_build.py
@@ -570,6 +570,7 @@ def test_force(cgmodel, force, force_type=None):
 def add_rosetta_exception_parameters(cgmodel, nonbonded_force, particle_index_1, particle_index_2):
     """
     """
+    rosetta_15_scaling = 0.2
     exception_list = []
     for exception in range(nonbonded_force.getNumExceptions()):
         index_1, index_2, charge, sigma, epsilon = nonbonded_force.getExceptionParameters(
@@ -588,15 +589,16 @@ def add_rosetta_exception_parameters(cgmodel, nonbonded_force, particle_index_1,
         charge_2 = cgmodel.get_particle_charge(particle_index_2)
         sigma_2 = cgmodel.get_sigma(particle_index_2).in_units_of(unit.nanometer)
         epsilon_2 = cgmodel.get_epsilon(particle_index_2).in_units_of(unit.kilojoule_per_mole)
-        sigma = (sigma_1.__add__(sigma_2)) / 2.0
-        epsilon = 0.2 * unit.sqrt(epsilon_1.__mul__(epsilon_2))
+        sigma = (sigma_1+sigma_2) / 2.0
+        epsilon = rosetta_15_scaling * unit.sqrt(epsilon_1*epsilon_2)
+        # Not clear we want the charge scaling here - charge potentials are more complex than needed.
         nonbonded_force.addException(
-            particle_index_1, particle_index_2, 0.2 * charge_1 * charge_2, sigma, epsilon
+            particle_index_1, particle_index_2, rosetta_15_scaling * charge_1 * charge_2, sigma, epsilon
         )
     return nonbonded_force
 
 
-def add_force(cgmodel, force_type=None, rosetta_scoring=False):
+def add_force(cgmodel, force_type=None, rosetta_functional_form=False):
     """
 
     Given a 'cgmodel' and 'force_type' as input, this function adds
@@ -662,7 +664,15 @@ def add_force(cgmodel, force_type=None, rosetta_scoring=False):
     if force_type == "Nonbonded":
 
         nonbonded_force = mm.NonbondedForce()
-        nonbonded_force.setNonbondedMethod(mm.NonbondedForce.NoCutoff)
+        if rosetta_functional_form:
+            # rosetta has a 4.5-6 A vdw cutoff.  Note the OpenMM cutoff may not be quite the same
+            # functional form as the Rosetta cutoff, but it should be somewhat close.
+            nonbonded_force.setNonbondedMethod(mm.NonbondedForce.CutoffNonPeriodic)
+            nonbonded_force.setCutoffDistance(0.6) # rosetta cutoff distance in nm
+            nonbonded_force.setUseSwitchingFunction()
+            nonbonded_force.setSwitchingDistance(0.45) # start of rosetta switching distance in nm
+        else:
+            nonbonded_force.setNonbondedMethod(mm.NonbondedForce.NoCutoff)
 
         for particle in range(cgmodel.num_beads):
             charge = cgmodel.get_particle_charge(particle)
@@ -671,12 +681,17 @@ def add_force(cgmodel, force_type=None, rosetta_scoring=False):
             nonbonded_force.addParticle(charge, sigma, epsilon)
 
         if len(cgmodel.bond_list) >= 1:
-            if not rosetta_scoring:
+            if not rosetta_functional_form:
+                # remove i+2 and i+3 bonds, do not scale i+4 bonds.
                 nonbonded_force.createExceptionsFromBonds(cgmodel.bond_list, 1.0, 1.0)
-            if rosetta_scoring:
-                # Remove i+3 interactions
+            else:
+                # Remove i+2, i+3, i+4 interactions
                 nonbonded_force.createExceptionsFromBonds(cgmodel.bond_list, 0.0, 0.0)
-                # Reduce the strength of i+4 interactions
+                # Reduce the strength of i+5 interactions, per rosetta functional form
+                # we find the i+5 interactions by looping over the torsions, and if
+                # a bond has one atom on the end (position 0 or 3) of the torsion,
+                # then the OTHER atom in bond is a i+5 interaction with the torsion atom
+                # on the OTHER end of the torsion.
                 for torsion in cgmodel.torsion_list:
                     for bond in cgmodel.bond_list:
                         if bond[0] not in torsion:
@@ -699,8 +714,6 @@ def add_force(cgmodel, force_type=None, rosetta_scoring=False):
                                 )
         cgmodel.system.addForce(nonbonded_force)
         force = nonbonded_force
-        # for particle in range(cgmodel.num_beads):
-        # print(force.getParticleParameters(particle))
 
     if force_type == "Angle":
         angle_force = mm.HarmonicAngleForce()
@@ -794,7 +807,7 @@ def test_forces(cgmodel):
     return success
 
 
-def build_system(cgmodel, rosetta_scoring=False, verify=True):
+def build_system(cgmodel, rosetta_functional_form=False, verify=True):
     """
     Builds an OpenMM `System() <https://simtk.org/api_docs/openmm/api4_1/python/classsimtk_1_1openmm_1_1openmm_1_1System.html>`_ object, given a CGModel() as input.
 
@@ -819,9 +832,17 @@ def build_system(cgmodel, rosetta_scoring=False, verify=True):
         system.addParticle(mass)
     cgmodel.system = system
 
-    # length_scale = cgmodel.bond_lengths['bb_bb_bond_length']
-    # box_vectors = [[100.0*length_scale._value,0.0,0.0],[0.0,100.0*length_scale._value,0.0],[0.0,0.0,100.0*length_scale._value]]
-    # system.setDefaultPeriodicBoxVectors(box_vectors[0],box_vectors[1],box_vectors[2])
+    if cgmodel.include_nonbonded_forces:
+        # Create nonbonded forces
+        cgmodel, nonbonded_force = add_force(
+            cgmodel, force_type="Nonbonded", rosetta_functional_form=rosetta_functional_form
+        )
+
+        # if cgmodel.positions != None:
+        # print("Testing the nonbonded forces")
+        # if not test_force(cgmodel,nonbonded_force,force_type="Nonbonded"):
+        # print("ERROR: there was a problem with the nonbonded force definitions.")
+        # exit()
 
     if cgmodel.include_bond_forces or cgmodel.constrain_bonds:
         if len(cgmodel.bond_list) > 0:
@@ -831,18 +852,6 @@ def build_system(cgmodel, rosetta_scoring=False, verify=True):
                 if not test_force(cgmodel, bond_force, force_type="Bond"):
                     print("ERROR: The bond force definition is giving 'nan'")
                     exit()
-
-    if cgmodel.include_nonbonded_forces:
-        # Create nonbonded forces
-        cgmodel, nonbonded_force = add_force(
-            cgmodel, force_type="Nonbonded", rosetta_scoring=rosetta_scoring
-        )
-
-        # if cgmodel.positions != None:
-        # print("Testing the nonbonded forces")
-        # if not test_force(cgmodel,nonbonded_force,force_type="Nonbonded"):
-        # print("ERROR: there was a problem with the nonbonded force definitions.")
-        # exit()
 
     if cgmodel.include_bond_angle_forces:
         if len(cgmodel.bond_angle_list) > 0:

--- a/examples/simulation/simulation_rosetta.py
+++ b/examples/simulation/simulation_rosetta.py
@@ -1,0 +1,128 @@
+import os
+from simtk import unit
+import foldamers
+import cg_openmm
+from simtk.openmm.app.pdbfile import PDBFile
+from foldamers.cg_model.cgmodel import CGModel
+from cg_openmm.simulation.tools import run_simulation
+import numpy as np
+
+###
+#
+# This example demonstrates how to run an NVT
+# simulation for a coarse grained model in OpenMM,
+# using a "CGModel" object built with the 'foldamers' software package.
+#
+###
+
+# Job settings
+output_directory = "output"
+if not os.path.exists(output_directory):
+    os.mkdir(output_directory)
+
+# OpenMM simulation settings
+print_frequency = 5000  # Number of steps to skip when printing output
+total_simulation_time = 2.0 * unit.nanosecond  # Units = picoseconds
+simulation_time_step = 5.0 * unit.femtosecond
+total_steps = int(np.floor(total_simulation_time/simulation_time_step))
+temperature = 300.0 * unit.kelvin
+friction = 1.0 / unit.picosecond
+
+# Coarse grained model settings
+polymer_length = 12
+backbone_lengths = [1]
+sidechain_lengths = [1]
+sidechain_positions = [0]
+include_bond_forces = True
+include_bond_angle_forces = True
+include_nonbonded_forces = True
+include_torsion_forces = True
+constrain_bonds = False
+rosetta_functional_form = True
+
+# Bond definitions
+bond_length = 0.2 * unit.nanometer
+bond_lengths = {
+    "bb_bb_bond_length": bond_length,
+    "bb_sc_bond_length": bond_length,
+    "sc_sc_bond_length": bond_length,
+}
+bond_force_constant = 1000 * unit.kilojoule_per_mole / unit.nanometer / unit.nanometer
+bond_force_constants = {
+    "bb_bb_bond_k": bond_force_constant,
+    "bb_sc_bond_k": bond_force_constant,
+    "sc_sc_bond_k": bond_force_constant,
+}
+
+# Particle definitions
+mass = 100.0 * unit.amu
+masses = {"backbone_bead_masses": mass, "sidechain_bead_masses": mass}
+r_min = 1.5 * bond_length  # Lennard-Jones potential r_min
+# Factor of /(2.0**(1/6)) is applied to convert r_min to sigma
+sigma = r_min / (2.0 ** (1.0 / 6.0))
+sigmas = {"bb_sigma": sigma, "sc_sigma": sigma}
+epsilon = 0.5 * unit.kilojoule_per_mole
+epsilons = {"bb_eps": epsilon, "sc_eps": epsilon}
+
+# Bond angle definitions
+bond_angle_force_constant = 50.0 * unit.kilojoule_per_mole / unit.radian / unit.radian
+bond_angle_force_constants = {
+    "bb_bb_bb_angle_k": bond_angle_force_constant,
+    "bb_bb_sc_angle_k": bond_angle_force_constant,
+}
+bb_bb_bb_equil_bond_angle = 120.0 * unit.degrees
+bb_bb_sc_equil_bond_angle = 120.0 * unit.degrees
+equil_bond_angles = {
+    "bb_bb_bb_angle_0": bb_bb_bb_equil_bond_angle,
+    "bb_bb_sc_angle_0": bb_bb_sc_equil_bond_angle,
+}
+
+# Torsion angle definitions
+torsion_force_constant = 20.0 * unit.kilojoule_per_mole
+torsion_force_constants = {"bb_bb_bb_bb_torsion_k": torsion_force_constant}
+bb_bb_bb_bb_equil_torsion_angle = 78.0 * unit.degrees
+bb_bb_bb_sc_equil_torsion_angle = 78.0 * unit.degrees
+equil_torsion_angles = {"bb_bb_bb_bb_torsion_0": bb_bb_bb_bb_equil_torsion_angle,
+                        "bb_bb_bb_sc_torsion_0": bb_bb_bb_sc_equil_torsion_angle
+}
+torsion_periodicities = {"bb_bb_bb_bb_period": 3, "bb_bb_bb_sc_period":3}
+
+# Get initial positions from local file
+positions = PDBFile("helix2.pdb").getPositions()
+
+# Build a coarse grained model
+cgmodel = CGModel(
+    polymer_length=polymer_length,
+    backbone_lengths=backbone_lengths,
+    sidechain_lengths=sidechain_lengths,
+    sidechain_positions=sidechain_positions,
+    masses=masses,
+    sigmas=sigmas,
+    epsilons=epsilons,
+    bond_lengths=bond_lengths,
+    bond_force_constants=bond_force_constants,
+    bond_angle_force_constants=bond_angle_force_constants,
+    torsion_force_constants=torsion_force_constants,
+    equil_bond_angles=equil_bond_angles,
+    equil_torsion_angles=equil_torsion_angles,
+    torsion_periodicities=torsion_periodicities,
+    include_nonbonded_forces=include_nonbonded_forces,
+    include_bond_forces=include_bond_forces,
+    include_bond_angle_forces=include_bond_angle_forces,
+    include_torsion_forces=include_torsion_forces,
+    constrain_bonds=constrain_bonds,
+    rosetta_functional_form=rosetta_functional_form,
+    positions=positions,
+)
+
+# Run a simulation
+print("Running a simulation.")
+run_simulation(
+    cgmodel,
+    total_simulation_time,
+    simulation_time_step,
+    temperature,
+    friction=friction,
+    print_frequency=print_frequency,
+    output_directory=output_directory,
+)


### PR DESCRIPTION
* cleaned up some of the math in computing the Rosetta sigma and epsilon. 
* added the truncated cutoff at 4.5-6 A when running OpenMM
* Clarified which interactions were being included/excluded 
* Removed some comments that weren't needed.
* added a simulation_rosetta.py example.

Note that I have not _tested_ whether the energies are sufficiently similar - I just implemented the things that we think should be necessary to make the comparison work. 