### PR TITLE
Bootstrapping code for free energy / entropy / enthalpy of folding

### DIFF
--- a/cg_openmm/parameters/secondary_structure.py
+++ b/cg_openmm/parameters/secondary_structure.py
@@ -124,10 +124,10 @@ def expectations_fraction_contacts(fraction_native_contacts, temperature_list, f
     # Check the size of the fraction_native_contacts array:
     if np.shape(replica_energies)[2] != np.shape(fraction_native_contacts)[0]:
         # Mismatch in number of frames.
-        if np.shape(replica_energies_all[:,:,frame_begin::])[2] == np.shape(fraction_native_contacts)[0]:
+        if np.shape(replica_energies_all[:,:,frame_begin::sample_spacing])[2] == np.shape(fraction_native_contacts[::sample_spacing,:])[0]:
             # Correct starting frame, need to apply sampling stride:
             fraction_native_contacts = fraction_native_contacts[::sample_spacing,:]
-        elif np.shape(replica_energies_all)[3] == np.shape(fraction_native_contacts)[0]:
+        elif np.shape(replica_energies_all)[2] == np.shape(fraction_native_contacts)[0]:
             # This is the full fraction_native_contacts, slice production frames:
             fraction_native_contacts = fraction_native_contacts[production_start::sample_spacing,:]
 

--- a/cg_openmm/tests/test_native_contacts.py
+++ b/cg_openmm/tests/test_native_contacts.py
@@ -260,14 +260,35 @@ def test_expectations_fraction_contacts_pdb(tmpdir):
     
     # Test entropy/enthalpy of folding calculation:
     S_folding, H_folding = get_entropy_enthalpy(
-        deltaF_values['state0_state1'],
-        full_T_list,
-        plotfile_entropy=f"{output_directory}/entropy_folding.pdf",
-        plotfile_enthalpy=f"{output_directory}/enthalpy_folding.pdf",
+        deltaF_values, full_T_list,
+        )
+    
+    # Test free energy / entropy / enthalpy bootstrapping calculation:
+    # From bootstrapping:
+    (full_T_list_boot, deltaF_values_boot, deltaF_uncertainty_boot, \
+        deltaS_values_boot, deltaS_uncertainty_boot, \
+        deltaH_values_boot, deltaH_uncertainty_boot) = bootstrap_free_energy_folding(
+        array_folded_states,
+        temperature_list,
+        frame_begin=100,
+        sample_spacing=1,
+        output_data=output_data,
+        num_intermediate_states=num_intermediate_states,
+        n_sample_boot=200,
+        n_trial_boot=10,
     )
     
+    # Plot entropy/enthalpy results:
+    
+    plot_entropy_enthalpy(
+        full_T_list, S_folding, H_folding, deltaS_uncertainty_boot, deltaH_uncertainty_boot,
+        plotfile_entropy=f"{output_directory}/entropy_folding.pdf",
+        plotfile_enthalpy=f"{output_directory}/enthalpy_folding.pdf",
+        )
+        
     assert os.path.isfile(f"{output_directory}/entropy_folding.pdf")
     assert os.path.isfile(f"{output_directory}/enthalpy_folding.pdf")
+    
 
 def test_expectations_fraction_contacts_dcd(tmpdir):
     """See if we can determine native contacts expectations as a function of T"""

--- a/examples/evaluating_folding/free_energy/calc_free_energy_conformation.py
+++ b/examples/evaluating_folding/free_energy/calc_free_energy_conformation.py
@@ -10,6 +10,7 @@ from simtk import unit
 from cg_openmm.parameters.secondary_structure import *
 from cg_openmm.parameters.free_energy import *
 from cg_openmm.parameters.reweight import *
+from cg_openmm.utilities.util import fit_sigmoid
 from analyze_foldamers.ensembles.cluster import *
 import pickle
 
@@ -25,35 +26,40 @@ cgmodel = pickle.load(open( "stored_cgmodel.pkl", "rb" ))
 
 # Create list of trajectory files for clustering analysis
 number_replicas = 36
-pdb_file_list = []
+dcd_file_list_rep = []
 for i in range(number_replicas):
-    pdb_file_list.append("output/replica_%s.pdb" %(i+1))
+    dcd_file_list_rep.append("output/replica_%s.dcd" %(i+1))
 
 # Set clustering parameters
-n_clusters=2
-frame_start=0
+frame_start=100
 frame_stride=100
 frame_end=-1
     
-# Run KMeans clustering
-medoid_positions, cluster_size, cluster_rmsd = get_cluster_medoid_positions(
-    file_list=pdb_file_list,
+# Run DBSCAN clustering
+medoid_positions, cluster_size, cluster_rmsd, n_noise, silhouette_avg = get_cluster_medoid_positions_DBSCAN(
+    file_list=dcd_file_list_rep,
     cgmodel=cgmodel,
-    n_clusters=n_clusters,
     frame_start=frame_start,
     frame_stride=frame_stride,
     frame_end=-1,
-    output_dir=output_directory)
+    min_samples=10,
+    eps=0.1,
+    filter_ratio=0.10,
+    output_dir=output_directory
+)
     
 print(f"Intra-cluster rmsd: {cluster_rmsd}")
 
-# The smaller intra-cluster rmsd will be the folded state if it is very stable
-if cluster_rmsd[0] < cluster_rmsd[1]:
-    native_structure_file=f"{output_directory}/medoid_0.pdb"
-else:
-    native_structure_file=f"{output_directory}/medoid_1.pdb"
-    
-native_positions = PDBFile(native_structure_file).getPositions()
+k_min = np.argmin(cluster_rmsd)
+
+# Minimize energy of native structure
+native_positions, PE_start, PE_end, simulation = minimize_structure(
+    cgmodel,
+    medoid_positions[k_min],
+    output_file=f"medoid_{k_min}_min.dcd",
+)
+
+native_structure_file=f"medoid_{k_min}_min.dcd"
 
 # Set cutoff parameters:
 # Cutoff for native structure pairwise distances:
@@ -63,66 +69,148 @@ native_contact_cutoff = 3.5* unit.angstrom
 native_contact_cutoff_ratio = 1.0
 
 # Cutoff for native contact fraction folded vs. unfolded states:
-Q_folded = 0.7
+Q_folded = 0.4
 
-# Determine native contacts:
+ # Determine native contacts:
 native_contact_list, native_contact_distances, contact_type_dict = get_native_contacts(
     cgmodel,
-    native_positions,
+    native_structure_file,
     native_contact_cutoff
 )
 
 # Determine native contact fraction of current trajectories:
+rep_traj = md.load(dcd_file_list_rep[0],top=md.Topology.from_openmm(cgmodel.topology))
+nframes = rep_traj.n_frames
 
-Q, Q_avg, Q_stderr, decorrelation_spacing = fraction_native_contacts(
-    pdb_file_list,
+Q, Q_avg, Q_stderr, decorrelation_time = fraction_native_contacts(
+    cgmodel,
+    dcd_file_list_rep,
     native_contact_list,
     native_contact_distances,
-    frame_begin=4500,
+    frame_begin=frame_start,
     native_contact_cutoff_ratio=native_contact_cutoff_ratio
 )
 
-plot_native_contact_fraction(
+num_intermediate_states = 1
+
+results = expectations_fraction_contacts(
+    Q,
     temperature_list,
-    Q_avg,
-    Q_stderr,
-    plotfile="Q_vs_T.pdf",
+    frame_begin=frame_start,
+    sample_spacing=1,
+    output_data=output_data,
+    num_intermediate_states=num_intermediate_states,
 )
 
-array_folded_states = np.zeros((len(Q[:,0]),len(pdb_file_list)))
+plot_native_contact_fraction(
+    results["T"],
+    results["Q"],
+    results["dQ"],
+    plotfile=f"Q_expect_vs_T.pdf",
+)
 
-for rep in range(len(pdb_file_list)):
+print("T (K), native contact fraction")
+for t in range(len(results["T"])):
+    print(f"{results['T'][t].value_in_unit(unit.kelvin)}   {results['Q'][t]}")    
+
+# plot Q_avg vs. frame
+plot_native_contact_timeseries(
+    Q,
+    frame_begin=frame_start,
+    time_interval=10*unit.picosecond,
+    plot_per_page=3,
+    plotfile="Q_vs_time.pdf",
+    figure_title="Native contact fraction",
+)
+
+# fit to hyperbolic switching function
+param_opt, param_cov = fit_sigmoid(results["T"],results["Q"])
+
+array_folded_states = np.zeros((len(Q[:,0]),number_replicas))
+
+for rep in range(number_replicas):
     # Classify into folded/unfolded states:
     for frame in range(len(Q[:,rep])):
         if Q[frame,rep] >= Q_folded:
             # Folded
-            array_folded_states[frame,rep] = 1
+            array_folded_states[frame,rep] = 0
         else:
             # Unfolded
-            array_folded_states[frame,rep] = 0
+            array_folded_states[frame,rep] = 1
 
-num_intermediate_states = 1
+num_intermediate_states = 0  
 
 full_T_list, deltaF_values, deltaF_uncertainty = expectations_free_energy(
     array_folded_states,
     temperature_list,
+    frame_begin=frame_start,
+    sample_spacing=1,
     output_data=output_data,
-    num_intermediate_states=num_intermediate_states,
+    num_intermediate_states=0,
 )
     
-print(f"T (K), deltaF (J/mol), deltaF_uncertainty (J/mol)")
-for i in range(len(full_T_list)):
-    print(f"{full_T_list[i]:>6.4f}, {deltaF_values['state0_state1'][i]:>6.8f}, {deltaF_uncertainty['state0_state1'][i]:>6.8f}")
-      
 plot_free_energy_results(
     full_T_list,
     deltaF_values,
     deltaF_uncertainty,
     plotfile="free_energy.pdf"
+)        
+    
+F_unit = unit.kilojoule / unit.mole 
+S_unit = F_unit / unit.kelvin
+U_unit = F_unit
+    
+# Compute entropy and enthalpy
+deltaS_values, deltaU_values = get_entropy_enthalpy(deltaF_values, full_T_list)    
+    
+deltaF_values = deltaF_values['state0_state1'].value_in_unit(F_unit)
+deltaF_uncertainty = deltaF_uncertainty['state0_state1'].value_in_unit(F_unit)
+
+deltaS_values = deltaS_values['state0_state1'].value_in_unit(S_unit)
+deltaU_values = deltaU_values['state0_state1'].value_in_unit(U_unit)
+
+# Get uncertainties from bootstrapping:
+(full_T_list_boot, deltaF_values_boot, deltaF_uncertainty_boot, \
+    deltaS_values_boot, deltaS_uncertainty_boot, \
+    deltaU_values_boot, deltaU_uncertainty_boot) = bootstrap_free_energy_folding(
+    array_folded_states,
+    temperature_list,
+    frame_begin=frame_start,
+    sample_spacing=1,
+    output_data=output_data,
+    num_intermediate_states=0,
+    n_sample_boot=200,
+    n_trial_boot=10,
 )
 
-# Compute entropy and enthalpy of folding:
-S_folding, H_folding = get_entropy_enthalpy(
-    deltaF_values['state0_state1'],
-    full_T_list,
-)
+deltaF_values_boot = deltaF_values_boot['state0_state1'].value_in_unit(F_unit)
+deltaF_uncertainty_boot = deltaF_uncertainty_boot['state0_state1'].value_in_unit(F_unit)
+
+deltaS_values_boot = deltaS_values_boot['state0_state1'].value_in_unit(S_unit)
+deltaS_uncertainty_boot = deltaS_uncertainty_boot['state0_state1'].value_in_unit(S_unit)
+
+deltaU_values_boot = deltaU_values_boot['state0_state1'].value_in_unit(U_unit)
+deltaU_uncertainty_boot = deltaU_uncertainty_boot['state0_state1'].value_in_unit(U_unit)
+
+print(f"T (K), deltaF (kJ/mol), deltaF_boot, deltaF_uncertainty, deltaF_uncertainty_boot")
+for i in range(len(full_T_list)):
+    print(f"{full_T_list_boot[i].value_in_unit(unit.kelvin):>6.4f}, \
+        {deltaF_values[i]:>6.8f}, \
+        {deltaF_values_boot[i]:>6.8f}, \
+        {deltaF_uncertainty[i]:>6.8f}, \
+        {deltaF_uncertainty_boot[i]:>6.8f}")
+        
+print(f"\nT (K), deltaS (kJ/mol/K), deltaS_boot, deltaS_uncertainty_boot")
+for i in range(len(full_T_list)):
+    print(f"{full_T_list_boot[i].value_in_unit(unit.kelvin):>6.4f}, \
+        {deltaS_values[i]:>6.8f}, \
+        {deltaS_values_boot[i]:>6.8f}, \
+        {deltaS_uncertainty_boot[i]:>6.8f}")
+        
+print(f"\nT (K), deltaU (kJ/mol), deltaU_boot, deltaU_uncertainty_boot")
+for i in range(len(full_T_list)):
+    print(f"{full_T_list_boot[i].value_in_unit(unit.kelvin):>6.4f}, \
+        {deltaU_values[i]:>6.8f}, \
+        {deltaU_values_boot[i]:>6.8f}, \
+        {deltaU_uncertainty_boot[i]:>6.8f}")
+      


### PR DESCRIPTION
## Description
Added a function for computing uncertainty of free energy, entropy, and enthalpy of folding using a bootstrapping algorithm. 

Frames from the replica_energies and corresponding conformational state (assigned from native contact fraction) arrays are selected at random, with replacement, and the existing free energy code is run on the subset of data. Then, the free energy vs T curve is splined, and from the derivative we can get entropy and enthalpy. This procedure is repeated n times, and the uncertainty for each temperature is taken as the standard deviation over the n trials.

This should work for any number of conformational states, in which it computes the uncertainty for all possible conformational state changes, though I've only dealt with 2 state systems so far.

## Todos
  - [x] Clean up and add example

## Status
- [x] Ready to go