### PR TITLE
Update docs for cgmodel

### DIFF
--- a/cg_openmm/cg_model/cgmodel.py
+++ b/cg_openmm/cg_model/cgmodel.py
@@ -93,6 +93,7 @@ class CGModel(object):
     def __init__(
         self,
         particle_type_list={},
+        charges={},
         monomer_types=None,
         sequence=None,
         positions=None,

--- a/docs/cgmodel_class.rst
+++ b/docs/cgmodel_class.rst
@@ -1,5 +1,7 @@
 CGModel class
 =========================================================
 
-.. automodule:: cg_openmm.cg_model.cgmodel
+.. autoclass:: cg_openmm.cg_model.cgmodel.CGModel
     :members:
+    
+    .. automethod:: __init__


### PR DESCRIPTION
## Description
Fixing a bunch of docstring formatting issues in the cgmodel class, and cleaning up the documentation example for using cgmodel class.

## Questions
- Should we get rid of the 'charge' attribute of cgmodel? We currently have charge as part of the particle dictionaries, but getting rid of it may create some incompatibility with cgmodels we have saved previously 
- What is the 'exclusions' attribute of cgmodel used for?