### PR TITLE
Optimize native contacts

### DIFF
--- a/cg_openmm/parameters/free_energy.py
+++ b/cg_openmm/parameters/free_energy.py
@@ -656,5 +656,6 @@ def plot_free_energy_results(full_T_list, deltaF_values, deltaF_uncertainty,plot
     plt.ylabel(ylabel)
     pyplot.legend(legend_str)
     plt.savefig(f"{plotfile}")
+    plt.close()
 
     return

--- a/cg_openmm/parameters/secondary_structure.py
+++ b/cg_openmm/parameters/secondary_structure.py
@@ -312,7 +312,7 @@ def fraction_native_contacts(
 def optimize_Q_cut(
     cgmodel, native_structure_file, traj_file_list, output_data="output/output.nc",
     num_intermediate_states=0, frame_begin=0, frame_stride=1, opt_method='Nelder-Mead',
-    plotfile='native_contacts_opt.pdf'):
+    plotfile='native_contacts_opt.pdf', verbose=False):
     """
     Given a coarse grained model and a native structure as input
 
@@ -389,9 +389,12 @@ def optimize_Q_cut(
             
             param_opt, param_cov = fit_sigmoid(results["T"],results["Q"])
             
-            # print(f"nc_cut: {native_contact_cutoff}")
-            # print(f"nc_cut_ratio: {native_contact_cutoff_ratio}")
-            # print(param_opt)
+            
+            if verbose:
+                # Print parameters at each iteration:
+                print(f"native_contact_cutoff: {native_contact_cutoff}")
+                print(f"native_contact_cutoff_ratio: {native_contact_cutoff_ratio}")
+                print(f"sigmoid params: {param_opt}\n")
             
             return param_opt[3]**2
             
@@ -436,7 +439,7 @@ def optimize_Q_cut(
         num_intermediate_states=num_intermediate_states,
     )
     
-    param_opt, param_cov = fit_sigmoid(Q_expect_results["T"],Q_expect_results["Q"],plotfile=plotfile)
+    sigmoid_param_opt, sigmoid_param_cov = fit_sigmoid(Q_expect_results["T"],Q_expect_results["Q"],plotfile=plotfile)
     
     return native_contact_cutoff, native_contact_cutoff_ratio, opt_results, Q_expect_results, sigmoid_param_opt, sigmoid_param_cov, contact_type_dict
     

--- a/cg_openmm/parameters/secondary_structure.py
+++ b/cg_openmm/parameters/secondary_structure.py
@@ -12,27 +12,29 @@ from openmmtools.multistate import MultiStateReporter, ReplicaExchangeAnalyzer
 import pymbar
 from pymbar import timeseries
 import mdtraj as md
+from scipy.optimize import minimize
+from cg_openmm.utilities.util import fit_sigmoid  
 
 kB = unit.MOLAR_GAS_CONSTANT_R # Boltzmann constant
 
 def get_native_contacts(cgmodel, native_structure_file, native_contact_distance_cutoff):
     """
-        Given a coarse grained model, positions for that model, and positions for the native structure, this function calculates the fraction of native contacts for the model.
+    Given a coarse grained model, positions for that model, and positions for the native structure, this function calculates the fraction of native contacts for the model.
 
-        :param cgmodel: CGModel() class object
-        :type cgmodel: class
+    :param cgmodel: CGModel() class object
+    :type cgmodel: class
 
-        :param native_structure_file: Path to file ('pdb' or 'dcd') containing particle positions for the native structure.
-        :type native_structure_file: str
+    :param native_structure_file: Path to file ('pdb' or 'dcd') containing particle positions for the native structure.
+    :type native_structure_file: str
 
-        :param native_contact_distance_cutoff: The maximum distance for two nonbonded particles that are defined as "native",default=None
-        :type native_contact_distance_cutoff: `Quantity() <https://docs.openmm.org/development/api-python/generated/simtk.unit.quantity.Quantity.html>`_
+    :param native_contact_distance_cutoff: The maximum distance for two nonbonded particles that are defined as "native",default=None
+    :type native_contact_distance_cutoff: `Quantity() <https://docs.openmm.org/development/api-python/generated/simtk.unit.quantity.Quantity.html>`_
 
-        :returns:
-          - native_contact_list - A list of the nonbonded interactions whose inter-particle distances are less than the 'native_contact_cutoff_distance'.
-          - native_contact_distances - A Quantity numpy array of the native pairwise distances corresponding to native_contact_list
-          - contact_type_dict - A dictionary of {native contact particle type pair: counts}
-        """
+    :returns:
+       - native_contact_list - A list of the nonbonded interactions whose inter-particle distances are less than the 'native_contact_cutoff_distance'.
+       - native_contact_distances - A Quantity numpy array of the native pairwise distances corresponding to native_contact_list
+       - contact_type_dict - A dictionary of {native contact particle type pair: counts}
+    """
 
     # Parse native structure file
     if native_structure_file[-3:] == 'dcd':
@@ -72,7 +74,7 @@ def get_native_contacts(cgmodel, native_structure_file, native_contact_distance_
             # Found a new type of contact:
             # Only store counts in forward string of first encounter
             contact_type_dict[string_name] = 1
-            print(f"adding contact type {string_name} to dict") 
+            #print(f"adding contact type {string_name} to dict") 
         else:
             if (string_name in contact_type_dict.keys()) == True:
                 # Add to forward_string count:
@@ -301,43 +303,116 @@ def fraction_native_contacts(
     decorrelation_spacing = max_sample_spacing
         
     return Q, Q_avg, Q_stderr, decorrelation_spacing
+    
 
-def optimize_Q(cgmodel, native_structure, ensemble):
+def optimize_Q_cut(
+    cgmodel, temperature_list, native_structure_file, traj_file_list, output_data="output/output.nc",
+    num_intermediate_states=0, frame_begin=0, frame_stride=1, opt_method='Nelder-Mead'):
     """
-        Given a coarse grained model and a native structure as input
+    Given a coarse grained model and a native structure as input
 
-        :param cgmodel: CGModel() class object
-        :type cgmodel: class
+    :param cgmodel: CGModel() class object
+    :type cgmodel: class
 
-        :param native_structure: Positions for the native structure.
-        :type native_structure: np.array( float * unit.angstrom ( num_particles x 3 ) )
+    :param native_structure: Positions for the native structure.
+    :type native_structure: np.array( float * unit.angstrom ( num_particles x 3 ) )
 
-        :param ensemble: A list of poses that will be used to optimize the cutoff distance for defining native contacts
-        :type ensemble: List(positions(np.array(float*simtk.unit (shape = num_beads x 3))))
+    :param ensemble: A list of poses that will be used to optimize the cutoff distance for defining native contacts
+    :type ensemble: List(positions(np.array(float*simtk.unit (shape = num_beads x 3))))
 
-        :returns:
-          - native_structure_contact_distance_cutoff ( `Quantity() <https://docs.openmm.org/development/api-python/generated/simtk.unit.quantity.Quantity.html>`_ ) - The ideal distance below which two nonbonded, interacting particles should be defined as a "native contact"
-        """
+    :returns:
+       - native_structure_contact_distance_cutoff ( `Quantity() <https://docs.openmm.org/development/api-python/generated/simtk.unit.quantity.Quantity.html>`_ ) - The ideal distance below which two nonbonded, interacting particles should be defined as a "native contact"
+    """
 
-    cutoff_list = [(0.95 + i * 0.01) * cgmodel.get_sigma(0) for i in range(30)]
-
-    cutoff_Q_list = []
-    for cutoff in cutoff_list:
-        Q_list = []
-        for pose in ensemble:
-            Q = fraction_native_contacts(
-                cgmodel, pose, native_structure, native_structure_contact_distance_cutoff=cutoff
+    # Initial guess for native_contact_cutoff, native_contact_cutoff_ratio:
+    # TODO: estimate this from the cgmodel rather than hard coding
+    x0 = [3.0, 1.5]
+    
+    def minimize_sigmoid_width(x0):
+   
+        native_contact_cutoff = x0[0]
+        native_contact_cutoff_ratio = x0[1]
+        
+        # Determine native contacts:
+        native_contact_list, native_contact_distances, contact_type_dict = get_native_contacts(
+            cgmodel,
+            native_structure_file,
+            native_contact_cutoff*unit.angstrom,
+        )
+        
+        if len(native_contact_list) > 0:
+            # Get native contact fraction of all frames
+            Q, Q_avg, Q_stderr, decorrelation_time = fraction_native_contacts(
+                cgmodel,
+                traj_file_list,
+                native_contact_list,
+                native_contact_distances,
+                frame_begin=frame_begin,
+                native_contact_cutoff_ratio=native_contact_cutoff_ratio
             )
-            Q_list.append(Q)
 
-        mean_Q = mean(Q_list)
-        cutoff_Q_list.append(mean_Q)
+            # Get expectations 
+            results = expectations_fraction_contacts(
+                Q,
+                temperature_list,
+                frame_begin=frame_begin,
+                sample_spacing=frame_stride,
+                output_data=output_data,
+                num_intermediate_states=num_intermediate_states,
+            )
+            
+            param_opt, param_cov = fit_sigmoid(results["T"],results["Q"])
+            
+            print(f"nc_cut: {native_contact_cutoff}")
+            print(f"nc_cut_ratio: {native_contact_cutoff_ratio}")
+            print(param_opt)
+            
+            return param_opt[3]**2
+            
+            # Or, if we want to maximum the difference between the max and min Q:
+            # return 1-abs(param_opt[2]-param_opt[1])
+        
+        else:
+            # There are no native contacts for this iteration
+            return np.nan
+        
+    opt_results = minimize(minimize_sigmoid_width, x0,
+        method=opt_method, options={'xatol':0.001, 'fatol':0.001})
+    
+    # Repeat for final plotting:
+    native_contact_cutoff = opt_results.x[0] * unit.angstrom
+    native_contact_cutoff_ratio = opt_results.x[1]
+    
+    # Determine native contacts:
+    native_contact_list, native_contact_distances, contact_type_dict = get_native_contacts(
+        cgmodel,
+        native_structure_file,
+        native_contact_cutoff,
+    )
 
-    cutoff_Q_list.index(max(cutoff_Q_list))
+    # Get native contact fraction of all frames
+    Q, Q_avg, Q_stderr, decorrelation_time = fraction_native_contacts(
+        cgmodel,
+        traj_file_list,
+        native_contact_list,
+        native_contact_distances,
+        frame_begin=frame_begin,
+        native_contact_cutoff_ratio=native_contact_cutoff_ratio
+    )
 
-    native_structure_contact_distance_cutoff = cutoff_Q_list.index(max(cutoff_Q_list))
-
-    return native_structure_contact_distance_cutoff
+    # Get expectations 
+    results = expectations_fraction_contacts(
+        Q,
+        temperature_list,
+        frame_begin=frame_begin,
+        sample_spacing=frame_stride,
+        output_data=output_data,
+        num_intermediate_states=num_intermediate_states,
+    )
+    
+    param_opt, param_cov = fit_sigmoid(results["T"],results["Q"],plotfile="native_contacts_fit.pdf")
+    
+    return opt_results, param_opt, param_cov
     
 
 def plot_native_contact_fraction(temperature_list, Q, Q_uncertainty,plotfile="Q_vs_T.pdf"):

--- a/cg_openmm/tests/test_native_contacts.py
+++ b/cg_openmm/tests/test_native_contacts.py
@@ -197,7 +197,6 @@ def test_expectations_fraction_contacts_pdb(tmpdir):
 
     results = expectations_fraction_contacts(
         Q,
-        temperature_list,
         frame_begin=100,
         output_data=output_data,
         num_intermediate_states=num_intermediate_states,
@@ -354,7 +353,6 @@ def test_expectations_fraction_contacts_dcd(tmpdir):
 
     results = expectations_fraction_contacts(
         Q,
-        temperature_list,
         frame_begin=100,
         output_data=output_data,
         num_intermediate_states=num_intermediate_states,

--- a/cg_openmm/utilities/util.py
+++ b/cg_openmm/utilities/util.py
@@ -130,6 +130,10 @@ def fit_sigmoid(xdata, ydata, plotfile='Q_vs_T_fit.pdf', xlabel='T (K)', ylabel=
     
     :param ydata: y data series
     :type ydata: Quantity or numpy 1D array
+    
+    :returns:
+        - param_opt ( 1D numpy array ) - optimized sigmoid parameters (x0, y0, y1, d) 
+        - param_cov ( 2D numpy array ) - estimated covariance of param_opt
 
     """
     

--- a/cg_openmm/utilities/util.py
+++ b/cg_openmm/utilities/util.py
@@ -119,7 +119,7 @@ def lj_v(positions_1, positions_2, sigma, epsilon):
     rep = quot.__pow__(12.0)
     v = 4.0 * epsilon.__mul__(rep.__sub__(attr))
     return v
-    
+   
     
 def fit_sigmoid(xdata, ydata, plotfile='Q_vs_T_fit.pdf', xlabel='T (K)', ylabel='Q'):
     """
@@ -152,63 +152,68 @@ def fit_sigmoid(xdata, ydata, plotfile='Q_vs_T_fit.pdf', xlabel='T (K)', ylabel=
     def tanh_switch(x,x0,y0,y1,d):
         return (y0+y1)/2-((y0-y1)/2)*np.tanh(np.radians(x-x0)/d)
         
-    param_guess = [np.mean(xdata),0.15,0.85,(np.max(ydata)-np.min(ydata))/2]
+    param_guess = [np.mean(xdata),np.min(ydata),np.max(ydata),(np.max(xdata)-np.min(xdata))/10]
+    bounds = (
+        [np.min(xdata), 0, 0, 0],
+        [np.max(xdata), 1, 1, (np.max(xdata)-np.min(xdata))])
     
-    param_opt, param_cov = curve_fit(tanh_switch, xdata, ydata, param_guess)
+    param_opt, param_cov = curve_fit(tanh_switch, xdata, ydata, param_guess, bounds=bounds)
     
-    figure = plt.figure()
-    
-    xfit = np.linspace(np.min(xdata),np.max(xdata),1000)
-    yfit = tanh_switch(xfit,param_opt[0],param_opt[1],param_opt[2],param_opt[3])
-    
-    # Value of y at the critical value of x:
-    y_x0 = (param_opt[1]+param_opt[2])/2
-    y_x0_err = np.sqrt(np.power(param_cov[1,1],2)+np.power(param_cov[2,2],2))
-    
-    line1 = plt.plot(
-        xdata,
-        ydata,
-        'ok',
-        markersize=4,
-        fillstyle='none',
-        label='simulation data',
-    )
-    
-    line2 = plt.plot(
-        xfit,
-        yfit,
-        '-b',
-        label='hyperbolic fit',
-    )
-    
-    plt.xlabel(xlabel)
-    plt.ylabel(ylabel)
-    
-    plt.legend()
-    
-    xlim = plt.xlim()
-    ylim = plt.ylim()
-    
-    plt.text(
-        ((xlim[0]+xlim[1])/2),
-        (ylim[0]+0.75*(ylim[1]-ylim[0])),
-        r'$y(x)=\frac{y0+y1}{2}-\frac{y0-y1}{2}\left(\tanh\left(\frac{(x-x0)}{d}\right)\right)$',
-    )
-    
-    plt.text(
-        (xlim[0]+0.55*(xlim[1]-xlim[0])),
-        (ylim[0]+0.50*(ylim[1]-ylim[0])),
-        f'x0 = {param_opt[0]:.4e} \u00B1 {param_cov[0,0]:.4e}\n' \
-        f'y0 = {param_opt[1]:.4e} \u00B1 {param_cov[1,1]:.4e}\n' \
-        f'y1 = {param_opt[2]:.4e} \u00B1 {param_cov[2,2]:.4e}\n' \
-        f'd = {param_opt[3]:.4e} \u00B1 {param_cov[3,3]:.4e}\n' \
-        f'y(x0) = {y_x0:>.4e} \u00B1 {y_x0_err:.4e}',
-        {'fontsize': 8},
-        horizontalalignment='left',
-    )
-    
-    plt.savefig(plotfile)
-    plt.close()
+    if plotfile is not None:
+        figure = plt.figure()
+        
+        xfit = np.linspace(np.min(xdata),np.max(xdata),1000)
+        yfit = tanh_switch(xfit,param_opt[0],param_opt[1],param_opt[2],param_opt[3])
+        
+        # Value of y at the critical value of x:
+        y_x0 = (param_opt[1]+param_opt[2])/2
+        y_x0_err = np.sqrt(np.power(param_cov[1,1],2)+np.power(param_cov[2,2],2))
+        
+        line1 = plt.plot(
+            xdata,
+            ydata,
+            'ok',
+            markersize=4,
+            fillstyle='none',
+            label='simulation data',
+        )
+        
+        line2 = plt.plot(
+            xfit,
+            yfit,
+            '-b',
+            label='hyperbolic fit',
+        )
+        
+        plt.xlabel(xlabel)
+        plt.ylabel(ylabel)
+        
+        plt.legend()
+        
+        xlim = plt.xlim()
+        ylim = plt.ylim()
+        
+        plt.text(
+            (xlim[0]+0.05*(xlim[1]-xlim[0])),
+            (ylim[0]+0.60*(ylim[1]-ylim[0])),
+            r'$y(x)=\frac{y0+y1}{2}-\frac{y0-y1}{2}\left(\tanh\left(\frac{(x-x0)}{d}\right)\right)$',
+            {'fontsize': 10},
+        )
+        
+        plt.text(
+            (xlim[0]+0.05*(xlim[1]-xlim[0])),
+            (ylim[0]+0.25*(ylim[1]-ylim[0])),
+            f'x0 = {param_opt[0]:.4e} \u00B1 {param_cov[0,0]:.4e}\n' \
+            f'y0 = {param_opt[1]:.4e} \u00B1 {param_cov[1,1]:.4e}\n' \
+            f'y1 = {param_opt[2]:.4e} \u00B1 {param_cov[2,2]:.4e}\n' \
+            f'd = {param_opt[3]:.4e} \u00B1 {param_cov[3,3]:.4e}\n' \
+            f'y(x0) = {y_x0:>.4e} \u00B1 {y_x0_err:.4e}',
+            {'fontsize': 10},
+            horizontalalignment='left',
+        )
+        
+        plt.savefig(plotfile)
+        plt.close()
     
     return param_opt, param_cov
     


### PR DESCRIPTION
## Description
Adding a function for optimizing the native contact cutoff (distance cutoff for native structure to determine what the native contact pairs are) and cutoff ratio (distance cutoff for trajectory scan) to minimize the sigmoid width parameter. This seems to work for a few example foldamer systems so far.

**Example 1:** helix foldamer with sigma=2.25A, bond_eq=2A, k_bond=1000 kJ/mol, theta=140, alpha=-40:
![image](https://user-images.githubusercontent.com/64790444/99421451-6356bb80-28cc-11eb-960d-8b42e4ba574a.png)
Optimal native contact cutoff: 3.1091 A
Optimal native contact cutoff ratio: 1.8295

**Example 2:** double helix foldamer with sigma=2.25A, bond_eq=2A, k_bond=1000 kJ/mol, theta=170, alpha=-80:
![image](https://user-images.githubusercontent.com/64790444/99421499-72d60480-28cc-11eb-8394-ca8ea187d342.png)
Optimal native contact cutoff: 1.5820 A
Optimal native contact cutoff ratio: 2.6344

The high native contact cutoff ratios here make sense since the bonds are shrinking from roughly 2A to 1A during the transition. The native contact distances for the native structure will be much smaller than what the high temperature system can reach.

The optimization with scipy minimize using 'Nelder-mead' algorithm takes about 60 function evaluations - not great for speed but still only takes a few minutes.
