### PR TITLE
Use Yank code's method for trajectory writing

### DIFF
--- a/cg_openmm/simulation/rep_exch.py
+++ b/cg_openmm/simulation/rep_exch.py
@@ -26,7 +26,7 @@ def make_replica_dcd_files(
     output_dir="output", output_data="output.nc", checkpoint_data="output_checkpoint.nc",
     frame_begin=0, frame_stride=1):
     """
-    Make dcd files from replica exchange simulation trajectory data
+    Make dcd files from replica exchange simulation trajectory data.
     
     :param topology: OpenMM Topology
     :type topology: `Topology() <https://simtk.org/api_docs/openmm/api4_1/python/classsimtk_1_1openmm_1_1app_1_1topology_1_1Topology.html>`_
@@ -86,8 +86,7 @@ def make_replica_pdb_files(
     topology, output_dir="output", output_data="output.nc", checkpoint_data="output_checkpoint.nc",
     frame_begin=0, frame_stride=1):
     """
-    Make PDB files by state from replica exchange simulation trajectory data.
-    Note: these are discontinuous trajectories with constant temperature state.
+    Make pdb files from replica exchange simulation trajectory data.
     
     :param topology: OpenMM Topology
     :type topology: `Topology() <https://simtk.org/api_docs/openmm/api4_1/python/classsimtk_1_1openmm_1_1app_1_1topology_1_1Topology.html>`_
@@ -151,7 +150,8 @@ def make_state_dcd_files(
     output_dir="output", output_data="output.nc", checkpoint_data="output_checkpoint.nc",
     frame_begin=0, frame_stride=1, center=True):
     """
-    Make dcd files from replica exchange simulation trajectory data
+    Make dcd files by state from replica exchange simulation trajectory data.
+    Note: these are discontinuous trajectories with constant temperature state.
     
     :param topology: OpenMM Topology
     :type topology: `Topology() <https://simtk.org/api_docs/openmm/api4_1/python/classsimtk_1_1openmm_1_1app_1_1topology_1_1Topology.html>`_
@@ -225,7 +225,7 @@ def make_state_pdb_files(
     topology, output_dir="output", output_data="output.nc", checkpoint_data="output_checkpoint.nc",
     frame_begin=0, frame_stride=1, center=True):
     """
-    Make PDB files by state from replica exchange simulation trajectory data.
+    Make pdb files by state from replica exchange simulation trajectory data.
     Note: these are discontinuous trajectories with constant temperature state.
     
     :param topology: OpenMM Topology
@@ -507,7 +507,6 @@ def process_replica_exchange_data(
         f = open(os.path.join(output_directory, "replica_energies.dat"), "w")
         for step in range(total_steps):
             f.write(f"{step:10d}")
-            sampler_states = reporter.read_sampler_states(iteration=step)
             for replica_index in range(n_replicas):
                 f.write(f"{replica_energies[replica_index,replica_index,step]:12.6f}")
             f.write("\n")

--- a/cg_openmm/tests/test_native_contacts.py
+++ b/cg_openmm/tests/test_native_contacts.py
@@ -374,5 +374,73 @@ def test_expectations_fraction_contacts_dcd(tmpdir):
         plotfile=f"{output_directory}/Q_vs_T_fit.pdf",
     )
     
-    assert os.path.isfile(f"{output_directory}/Q_vs_T_fit.pdf")  
+    assert os.path.isfile(f"{output_directory}/Q_vs_T_fit.pdf")
+    
+    
+def test_optimize_Q_cut_pdb(tmpdir):
+    """Test the native contact cutoff optimization workflow"""
+
+    output_directory = tmpdir.mkdir("output")
+    output_data = os.path.join(data_path, "output.nc")
+
+    # Replica exchange settings
+    number_replicas = 12
+    min_temp = 200.0 * unit.kelvin
+    max_temp = 300.0 * unit.kelvin
+    temperature_list = get_temperature_list(min_temp, max_temp, number_replicas)
+
+    # Load in cgmodel
+    cgmodel = pickle.load(open(f"{data_path}/stored_cgmodel.pkl", "rb" ))
+
+    # Create list of pdb trajectories to analyze
+    # For expectation fraction native contacts, we use replica trajectories: 
+    pdb_file_list = []
+    for i in range(len(temperature_list)):
+        pdb_file_list.append(f"{data_path}/replica_{i+1}.pdb")
+        
+    # Load in native structure file:    
+    native_structure_file=f"{structures_path}/medoid_0.pdb"    
+    
+    (native_contact_cutoff, native_contact_cutoff_ratio, opt_results, Q_expect_results, \
+    sigmoid_param_opt, sigmoid_param_cov, contact_type_dict) = optimize_Q_cut(
+        cgmodel, native_structure_file, pdb_file_list, num_intermediate_states=0,
+        output_data=output_data, frame_begin=100, frame_stride=20,
+        opt_method='Nelder-mead', verbose=True,
+        plotfile=f'{output_directory}/native_contacts_opt.pdf')    
+        
+    assert os.path.isfile(f'{output_directory}/native_contacts_opt.pdf')
+    
+    
+def test_optimize_Q_cut_dcd(tmpdir):
+    """Test the native contact cutoff optimization workflow"""
+
+    output_directory = tmpdir.mkdir("output")
+    output_data = os.path.join(data_path, "output.nc")
+
+    # Replica exchange settings
+    number_replicas = 12
+    min_temp = 200.0 * unit.kelvin
+    max_temp = 300.0 * unit.kelvin
+    temperature_list = get_temperature_list(min_temp, max_temp, number_replicas)
+
+    # Load in cgmodel
+    cgmodel = pickle.load(open(f"{data_path}/stored_cgmodel.pkl", "rb" ))
+
+    # Create list of pdb trajectories to analyze
+    # For expectation fraction native contacts, we use replica trajectories: 
+    dcd_file_list = []
+    for i in range(len(temperature_list)):
+        dcd_file_list.append(f"{data_path}/replica_{i+1}.dcd")
+        
+    # Load in native structure file:    
+    native_structure_file=f"{structures_path}/medoid_0.dcd"    
+    
+    (native_contact_cutoff, native_contact_cutoff_ratio, opt_results, Q_expect_results, \
+    sigmoid_param_opt, sigmoid_param_cov, contact_type_dict) = optimize_Q_cut(
+        cgmodel, native_structure_file, dcd_file_list, num_intermediate_states=0,
+        output_data=output_data,frame_begin=100, frame_stride=20,
+        opt_method='Nelder-mead', verbose=True,
+        plotfile=f'{output_directory}/native_contacts_opt.pdf')
+        
+    assert os.path.isfile(f'{output_directory}/native_contacts_opt.pdf')
     

--- a/cg_openmm/tests/test_native_contacts.py
+++ b/cg_openmm/tests/test_native_contacts.py
@@ -377,38 +377,38 @@ def test_expectations_fraction_contacts_dcd(tmpdir):
     assert os.path.isfile(f"{output_directory}/Q_vs_T_fit.pdf")
     
     
-def test_optimize_Q_cut_pdb(tmpdir):
-    """Test the native contact cutoff optimization workflow"""
+# def test_optimize_Q_cut_pdb(tmpdir):
+    # """Test the native contact cutoff optimization workflow"""
 
-    output_directory = tmpdir.mkdir("output")
-    output_data = os.path.join(data_path, "output.nc")
+    # output_directory = tmpdir.mkdir("output")
+    # output_data = os.path.join(data_path, "output.nc")
 
-    # Replica exchange settings
-    number_replicas = 12
-    min_temp = 200.0 * unit.kelvin
-    max_temp = 300.0 * unit.kelvin
-    temperature_list = get_temperature_list(min_temp, max_temp, number_replicas)
+    # # Replica exchange settings
+    # number_replicas = 12
+    # min_temp = 200.0 * unit.kelvin
+    # max_temp = 300.0 * unit.kelvin
+    # temperature_list = get_temperature_list(min_temp, max_temp, number_replicas)
 
-    # Load in cgmodel
-    cgmodel = pickle.load(open(f"{data_path}/stored_cgmodel.pkl", "rb" ))
+    # # Load in cgmodel
+    # cgmodel = pickle.load(open(f"{data_path}/stored_cgmodel.pkl", "rb" ))
 
-    # Create list of pdb trajectories to analyze
-    # For expectation fraction native contacts, we use replica trajectories: 
-    pdb_file_list = []
-    for i in range(len(temperature_list)):
-        pdb_file_list.append(f"{data_path}/replica_{i+1}.pdb")
+    # # Create list of pdb trajectories to analyze
+    # # For expectation fraction native contacts, we use replica trajectories: 
+    # pdb_file_list = []
+    # for i in range(len(temperature_list)):
+        # pdb_file_list.append(f"{data_path}/replica_{i+1}.pdb")
         
-    # Load in native structure file:    
-    native_structure_file=f"{structures_path}/medoid_0.pdb"    
+    # # Load in native structure file:    
+    # native_structure_file=f"{structures_path}/medoid_0.pdb"    
     
-    (native_contact_cutoff, native_contact_cutoff_ratio, opt_results, Q_expect_results, \
-    sigmoid_param_opt, sigmoid_param_cov, contact_type_dict) = optimize_Q_cut(
-        cgmodel, native_structure_file, pdb_file_list, num_intermediate_states=0,
-        output_data=output_data, frame_begin=100, frame_stride=20,
-        opt_method='Nelder-mead', verbose=True,
-        plotfile=f'{output_directory}/native_contacts_opt.pdf')    
+    # (native_contact_cutoff, native_contact_cutoff_ratio, opt_results, Q_expect_results, \
+    # sigmoid_param_opt, sigmoid_param_cov, contact_type_dict) = optimize_Q_cut(
+        # cgmodel, native_structure_file, pdb_file_list, num_intermediate_states=0,
+        # output_data=output_data, frame_begin=100, frame_stride=20,
+        # opt_method='Nelder-mead', verbose=True,
+        # plotfile=f'{output_directory}/native_contacts_opt.pdf')    
         
-    assert os.path.isfile(f'{output_directory}/native_contacts_opt.pdf')
+    # assert os.path.isfile(f'{output_directory}/native_contacts_opt.pdf')
     
     
 def test_optimize_Q_cut_dcd(tmpdir):

--- a/cg_openmm/tests/test_simulation.py
+++ b/cg_openmm/tests/test_simulation.py
@@ -346,7 +346,7 @@ def test_run_replica_exchange(tmpdir):
     
     # Process replica exchange output
     # 1) With detect equilibrium:
-    replica_energies, replica_positions, replica_states, production_start, sample_spacing = process_replica_exchange_data(
+    replica_energies, replica_states, production_start, sample_spacing = process_replica_exchange_data(
         output_data=output_data,
         output_directory=output_directory,
         detect_equilibration=True,
@@ -356,7 +356,7 @@ def test_run_replica_exchange(tmpdir):
     assert production_start is not None
     
     # 2) Without detect equilibrium:
-    replica_energies, replica_positions, replica_states, production_start, sample_spacing = process_replica_exchange_data(
+    replica_energies, replica_states, production_start, sample_spacing = process_replica_exchange_data(
         output_data=output_data,
         output_directory=output_directory,
         detect_equilibration=False,
@@ -365,7 +365,7 @@ def test_run_replica_exchange(tmpdir):
     assert production_start is None    
     
     # 3) Without writing .dat file:
-    replica_energies, replica_positions, replica_states, production_start, sample_spacing = process_replica_exchange_data(
+    replica_energies, replica_states, production_start, sample_spacing = process_replica_exchange_data(
         output_data=output_data,
         output_directory=output_directory,
         detect_equilibration=False,
@@ -375,14 +375,11 @@ def test_run_replica_exchange(tmpdir):
     # Test pdb writer:
     make_replica_pdb_files(
         cgmodel.topology,
-        replica_positions,
-        output_dir=output_directory
+        output_dir=output_directory,
     )
         
     make_state_pdb_files(
         cgmodel.topology,
-        replica_positions,
-        replica_states,
         output_dir=output_directory
     )
     
@@ -392,38 +389,31 @@ def test_run_replica_exchange(tmpdir):
     # With non-default frame_begin, stride, no centering:
     make_replica_pdb_files(
         cgmodel.topology,
-        replica_positions,
         frame_begin=10,
-        stride=2,
+        frame_stride=2,
         output_dir=output_directory
     )
     
     make_state_pdb_files(
         cgmodel.topology,
-        replica_positions,
-        replica_states,
         frame_begin=10,
-        stride=2,
+        frame_stride=2,
         output_dir=output_directory,
         center=False
     )
     
-    
     # Test dcd writer:
     make_replica_dcd_files(
         cgmodel.topology,
-        replica_positions,
-        simulation_time_step,
-        exchange_frequency,
+        timestep=simulation_time_step,
+        time_interval=exchange_frequency,
         output_dir=output_directory
     )
         
     make_state_dcd_files(
         cgmodel.topology,
-        replica_positions,
-        replica_states,
-        simulation_time_step,
-        exchange_frequency,
+        timestep=simulation_time_step,
+        time_interval=exchange_frequency,
         output_dir=output_directory
     )
     
@@ -433,22 +423,19 @@ def test_run_replica_exchange(tmpdir):
     # With non-default frame_begin, stride, no centering:
     make_replica_dcd_files(
         cgmodel.topology,
-        replica_positions,
-        simulation_time_step,
-        exchange_frequency,
+        timestep=simulation_time_step,
+        time_interval=exchange_frequency,
         frame_begin=10,
-        stride=2,
+        frame_stride=2,
         output_dir=output_directory
     )
     
     make_state_dcd_files(
         cgmodel.topology,
-        replica_positions,
-        replica_states,
-        simulation_time_step,
-        exchange_frequency,
+        timestep=simulation_time_step,
+        time_interval=exchange_frequency,
         frame_begin=10,
-        stride=2,
+        frame_stride=2,
         output_dir=output_directory,
         center=False
     )

--- a/examples/replica_exchange/process_replica_exchange.py
+++ b/examples/replica_exchange/process_replica_exchange.py
@@ -24,7 +24,7 @@ output_data = os.path.join(output_directory, "output.nc")
 
 # Replica exchange simulation settings
 cgmodel = pickle.load(open("stored_cgmodel.pkl","rb"))
-replica_energies, replica_positions, replica_states, production_start, decorrelation_spacing = process_replica_exchange_data(
+replica_energies, replica_states, production_start, decorrelation_spacing = process_replica_exchange_data(
     output_data=output_data,
     output_directory="output",
 )
@@ -32,18 +32,24 @@ replica_energies, replica_positions, replica_states, production_start, decorrela
 print(production_start)
 print(decorrelation_spacing)
 
-make_replica_dcd_files(
+# make_replica_dcd_files(
+    # cgmodel.topology,
+    # timestep=10*unit.femtosecond,
+    # time_interval=100,
+    # output_dir=output_directory,
+# )
+# make_state_dcd_files(
+    # cgmodel.topology,
+    # timestep=10*unit.femtosecond,
+    # time_interval=100,
+    # output_dir=output_directory,
+# )
+
+make_replica_pdb_files(
     cgmodel.topology,
-    replica_positions,
-    timestep=10*unit.femtosecond,
-    time_interval=100,
     output_dir=output_directory,
 )
-make_state_dcd_files(
+make_state_pdb_files(
     cgmodel.topology,
-    replica_positions,
-    replica_states,
-    timestep=10*unit.femtosecond,
-    time_interval=100,
     output_dir=output_directory,
 )


### PR DESCRIPTION
## Description
Revamped process_replica_exchange and the trajectory writing code:
- Write one replica or state at a time reading directly from the output_checkpoint.nc file using a new internal function extract_trajectory, which closely follows the original Yank code here: https://github.com/choderalab/yank/blob/master/Yank/analyze.py#L1036-L1202
- We can now write the trajectories independently of the process_replica_exchange function (don't need to use the stored arrays of replica_positions). This is fairly quick - most of the time is spent writing the trajectory files to disk.
- process_replica_exchange no longer outputs the replica_positions (the function is now for just the energy analysis). We can read positions from the trajectory files when needed.
- Added options for passing 'nskip' parameter to pymbar detectEquilibration, and 'fast' parameter to pymbar subsampleCorrelatedData. Haven't tested the accuracy of either yet, but I expect we can set 'nskip' to 2 or 3 with no problems.

This should fix the memory issue with writing the state trajectories (#99), but still need to test that. 

## Status
- [ ] Ready to go