### PR TITLE
Binary interaction parameters

### DIFF
--- a/cg_openmm/build/cg_build.py
+++ b/cg_openmm/build/cg_build.py
@@ -633,9 +633,6 @@ def add_force(cgmodel, force_type=None, rosetta_functional_form=False):
             nonbonded_force = mm.CustomNonbondedForce(f"4*epsilon*((sigma/r)^12-(sigma/r)^6); sigma=0.5*(sigma1+sigma2); epsilon=(1-{kappa})*sqrt(epsilon1*epsilon2)")
             nonbonded_force.addPerParticleParameter("sigma")
             nonbonded_force.addPerParticleParameter("epsilon")
-            
-            print(cgmodel.binary_interaction_parameters)
-            
                 
             # We need to specify a default value of kappa when adding global parameter
             # nonbonded_force.addGlobalParameter("kappa",kappa)

--- a/cg_openmm/build/cg_build.py
+++ b/cg_openmm/build/cg_build.py
@@ -622,58 +622,102 @@ def add_force(cgmodel, force_type=None, rosetta_functional_form=False):
 
     if force_type == "Nonbonded":
 
-        nonbonded_force = mm.NonbondedForce()
-
-        if rosetta_functional_form:
-            # rosetta has a 4.5-6 A vdw cutoff.  Note the OpenMM cutoff may not be quite the same
-            # functional form as the Rosetta cutoff, but it should be somewhat close.
-            nonbonded_force.setNonbondedMethod(mm.NonbondedForce.CutoffNonPeriodic)
-            nonbonded_force.setCutoffDistance(0.6)  # rosetta cutoff distance in nm
-            nonbonded_force.setUseSwitchingFunction(True)
-            nonbonded_force.setSwitchingDistance(0.45)  # start of rosetta switching distance in nm
-        else:
+        if cgmodel.binary_interaction_parameters:
+            # If not an empty dictionary, use the parameters within
+            
+            for key, value in cgmodel.binary_interaction_parameters.items():
+                # TODO: make kappa work for systems with more than 2 bead types
+                kappa = value
+            
+            # Use custom nonbonded force with binary interaction parameter
+            nonbonded_force = mm.CustomNonbondedForce(f"4*epsilon*((sigma/r)^12-(sigma/r)^6); sigma=0.5*(sigma1+sigma2); epsilon=(1-{kappa})*sqrt(epsilon1*epsilon2)")
+            nonbonded_force.addPerParticleParameter("sigma")
+            nonbonded_force.addPerParticleParameter("epsilon")
+            
+            print(cgmodel.binary_interaction_parameters)
+            
+                
+            # We need to specify a default value of kappa when adding global parameter
+            # nonbonded_force.addGlobalParameter("kappa",kappa)
+            
+            # TODO: add the rosetta_function_form switching function
             nonbonded_force.setNonbondedMethod(mm.NonbondedForce.NoCutoff)
+            
+            for particle in range(cgmodel.num_beads):
+                # We don't need to define charge here, though we should add it in the future
+                # We also don't need to define kappa since it is a global parameter
+                sigma = cgmodel.get_particle_sigma(particle)
+                epsilon = cgmodel.get_particle_epsilon(particle)
+                nonbonded_force.addParticle((sigma, epsilon))   
 
-        for particle in range(cgmodel.num_beads):
-            charge = cgmodel.get_particle_charge(particle)
-            sigma = cgmodel.get_particle_sigma(particle)
-            epsilon = cgmodel.get_particle_epsilon(particle)
-            nonbonded_force.addParticle(charge, sigma, epsilon)
+            if len(cgmodel.bond_list) >= 1:
+                #***Note: customnonbonded force uses 'Exclusion' rather than 'Exception'
+                # Each of these also takes different arguments
+                if not rosetta_functional_form:
+                    # This should not be applied if there are no angle forces.
+                    if cgmodel.include_bond_angle_forces:
+                        bond_cut = 2 # Particles separated by this many bonds or fewer are excluded
+                        # A value of 2 means that 1-2, 1-3 interactions are 0, 1-4 interactions are 1
+                        nonbonded_force.createExclusionsFromBonds(cgmodel.bond_list, bond_cut)
+                    else:
+                        # Just remove the 1-2 nonbonded interactions.
+                        # For customNonbondedForce, don't need to set charge product and epsilon here
+                        for bond in cgmodel.bond_list:
+                            nonbonded_force.addExclusion(bond[0], bond[1])
+            
+        else:
+            nonbonded_force = mm.NonbondedForce()
 
-        if len(cgmodel.bond_list) >= 1:
-            if not rosetta_functional_form:
-                # This should not be applied if there are no angle forces.
-                if cgmodel.include_bond_angle_forces:
-                    nonbonded_force.createExceptionsFromBonds(cgmodel.bond_list, 1.0, 1.0)
-                else:
-                    # Just remove the 1-2 nonbonded interactions.
-                    # If charge product and epsilon are 0, the interaction is omitted.
-                    for bond in cgmodel.bond_list:
-                        nonbonded_force.addException(bond[0], bond[1], 0.0, 1.0, 0.0)
             if rosetta_functional_form:
-                # Remove i+3 interactions
-                nonbonded_force.createExceptionsFromBonds(cgmodel.bond_list, 0.0, 0.0)
-                # Reduce the strength of i+4 interactions
-                for torsion in cgmodel.torsion_list:
-                    for bond in cgmodel.bond_list:
-                        if bond[0] not in torsion:
-                            if bond[1] == torsion[0]:
-                                nonbonded_force = add_rosetta_exception_parameters(
-                                    cgmodel, nonbonded_force, bond[0], torsion[3]
-                                )
-                            if bond[1] == torsion[3]:
-                                nonbonded_force = add_rosetta_exception_parameters(
-                                    cgmodel, nonbonded_force, bond[0], torsion[0]
-                                )
-                        if bond[1] not in torsion:
-                            if bond[0] == torsion[0]:
-                                nonbonded_force = add_rosetta_exception_parameters(
-                                    cgmodel, nonbonded_force, bond[1], torsion[3]
-                                )
-                            if bond[0] == torsion[3]:
-                                nonbonded_force = add_rosetta_exception_parameters(
-                                    cgmodel, nonbonded_force, bond[1], torsion[0]
-                                )
+                # rosetta has a 4.5-6 A vdw cutoff.  Note the OpenMM cutoff may not be quite the same
+                # functional form as the Rosetta cutoff, but it should be somewhat close.
+                nonbonded_force.setNonbondedMethod(mm.NonbondedForce.CutoffNonPeriodic)
+                nonbonded_force.setCutoffDistance(0.6)  # rosetta cutoff distance in nm
+                nonbonded_force.setUseSwitchingFunction(True)
+                nonbonded_force.setSwitchingDistance(0.45)  # start of rosetta switching distance in nm
+            else:
+                nonbonded_force.setNonbondedMethod(mm.NonbondedForce.NoCutoff)
+
+            for particle in range(cgmodel.num_beads):
+                charge = cgmodel.get_particle_charge(particle)
+                sigma = cgmodel.get_particle_sigma(particle)
+                epsilon = cgmodel.get_particle_epsilon(particle)
+                nonbonded_force.addParticle(charge, sigma, epsilon)
+
+            if len(cgmodel.bond_list) >= 1:
+                if not rosetta_functional_form:
+                    # This should not be applied if there are no angle forces.
+                    if cgmodel.include_bond_angle_forces:
+                        nonbonded_force.createExceptionsFromBonds(cgmodel.bond_list, 1.0, 1.0)
+                    else:
+                        # Just remove the 1-2 nonbonded interactions.
+                        # If charge product and epsilon are 0, the interaction is omitted.
+                        for bond in cgmodel.bond_list:
+                            nonbonded_force.addException(bond[0], bond[1], 0.0, 1.0, 0.0)
+                if rosetta_functional_form:
+                    # Remove i+3 interactions
+                    nonbonded_force.createExceptionsFromBonds(cgmodel.bond_list, 0.0, 0.0)
+                    # Reduce the strength of i+4 interactions
+                    for torsion in cgmodel.torsion_list:
+                        for bond in cgmodel.bond_list:
+                            if bond[0] not in torsion:
+                                if bond[1] == torsion[0]:
+                                    nonbonded_force = add_rosetta_exception_parameters(
+                                        cgmodel, nonbonded_force, bond[0], torsion[3]
+                                    )
+                                if bond[1] == torsion[3]:
+                                    nonbonded_force = add_rosetta_exception_parameters(
+                                        cgmodel, nonbonded_force, bond[0], torsion[0]
+                                    )
+                            if bond[1] not in torsion:
+                                if bond[0] == torsion[0]:
+                                    nonbonded_force = add_rosetta_exception_parameters(
+                                        cgmodel, nonbonded_force, bond[1], torsion[3]
+                                    )
+                                if bond[0] == torsion[3]:
+                                    nonbonded_force = add_rosetta_exception_parameters(
+                                        cgmodel, nonbonded_force, bond[1], torsion[0]
+                                    )
         cgmodel.system.addForce(nonbonded_force)
         force = nonbonded_force
 
@@ -888,7 +932,7 @@ def build_system(cgmodel, rosetta_functional_form=False, verify=True):
     if cgmodel.include_nonbonded_forces:
         # Create nonbonded forces
         cgmodel, nonbonded_force = add_force(
-            cgmodel, force_type="Nonbonded", rosetta_functional_form=rosetta_functional_form
+            cgmodel, force_type="Nonbonded", rosetta_functional_form=rosetta_functional_form,
         )
 
     if cgmodel.include_bond_forces or cgmodel.constrain_bonds:

--- a/cg_openmm/cg_model/cgmodel.py
+++ b/cg_openmm/cg_model/cgmodel.py
@@ -443,7 +443,7 @@ class CGModel(object):
                         string += c
                 kappa_list.append(string)
                 
-                if kappa_list[-2] != 'binary' and kappa_list[-1] != 'interaction':
+                if kappa_list[-2] != 'binary' or kappa_list[-1] != 'interaction':
                     print(f'Incorrect suffix for binary interaction parameter for {binary_interaction_parameters[key]}')
                     exit()
   

--- a/cg_openmm/cg_model/cgmodel.py
+++ b/cg_openmm/cg_model/cgmodel.py
@@ -104,6 +104,7 @@ class CGModel(object):
         torsion_periodicities={},
         equil_bond_angles={},
         torsion_phase_angles={},
+        binary_interaction_parameters={},
         constrain_bonds=False,
         include_nonbonded_forces=True,
         include_bond_forces=True,
@@ -154,6 +155,9 @@ class CGModel(object):
         :param torsion_phase_angles: Periodic torsion phase angle for all unique torsion angle definitions (default = 0)
         :type torsion_phase_angles: dict( 'type_name1_type_name2_type_name3_type_name4_torsion_0': `Quantity() <https://docs.openmm.org/development/api-python/generated/simtk.unit.quantity.Quantity.html>`_ ) )
 
+        :param binary_interaction_parameters: Binary interaction parameters used to scale nonbonded interactions between unlike particles (default=None)
+        :type binary_interaction_parameters: dict( 'type_name1_type_name2_binary_interaction': float )
+        
         :param constrain_bonds: Option to use rigid bond constaints during a simulation of the energy for the system (default = False)
         :type constrain_bonds: Bool
 
@@ -241,6 +245,10 @@ class CGModel(object):
 
         # Assign particle properties
         self.particle_types = add_new_elements(self)
+        
+        # Assign binary interaction parameters
+        self.binary_interaction_parameters = binary_interaction_parameters
+        self._validate_binary_interaction
 
         # Assign bonded force properties
         self.bond_force_constants = bond_force_constants
@@ -414,7 +422,43 @@ class CGModel(object):
                 particle["charge"] = self.default_charge
 
         return particle_type_list
-
+        
+        
+    def _validate_binary_interaction(self, binary_interaction_parameters):    
+        """
+        Check that the binary interaction definitions are valid.
+        Each entry in the dictionary should be 'type_name1_type_name2_binary_interaction': float
+        """
+        
+        if binary_interaction_parameters is not None:
+            for key, value in binary_interaction_parameters.items():
+                # Extract the particle types:
+                kappa_list = []
+                string = ""
+                for c in key:
+                    if c == '_':
+                        kappa_list.append(string)
+                        string = ""
+                    else:
+                        string += c
+                kappa_list.append(string)
+                
+                if kappa_list[-2] != 'binary' and kappa_list[-1] != 'interaction':
+                    print(f'Incorrect suffix for binary interaction parameter for {binary_interaction_parameters[key]}')
+                    exit()
+  
+                # Use the first two particles in the dictionary key:
+                kappa_particle_list = kappa_list[0:2]
+                
+                for particle in kappa_particle_list:
+                    if particle in self.particle_type_list:
+                        pass
+                    else:
+                        print(f'Invalid particle name {particle} in binary interaction parameter definition') 
+                        exit()
+                        
+        return
+        
         
     def build_polymer(self, sequence):
         """


### PR DESCRIPTION
## Description
Here's what I propose for modifying the interaction strength between backbone and sidechain particles (see #107). I've added an attribute 'binary_interaction_parameters' to cgmodel which can be set like this:

```
binary_interaction_parameters = {
        "bb_sc_binary_interaction": 0.5}
```

If binary_interaction_parameters is used when constructing a cgmodel, a customNonbondedForce style is used:
`nonbonded_force = mm.CustomNonbondedForce(f"4*epsilon*((sigma/r)^12-(sigma/r)^6); sigma=0.5*(sigma1+sigma2); epsilon=(1-{kappa})*sqrt(epsilon1*epsilon2)")` where kappa is the binary interaction parameter

If binary_interaction_parameters is not used or is empty, the old NonbondedForce code is used.

There are some differences in the customNonbondedForce vs. NonbondedForce functions for creating nonbonded exclusions, but everything seems to be working.

I added a regression test in test_simulation which compares the energies before and after energy minimization for 1) no binary interaction parameter set, and 2) binary interaction parameter set to 0 (no scaling of interaction strength). The energies are very slightly different (about 1 Joule/mol for a 24mer 1b1s system which has an energy of about -73kJ/mol), but close enough that we know that the forces are getting set up properly.

## Todos
  - [ ] Right now this only works for one pair of particles. If we have 3 particles, we need to make it more general - what needs to be updated is the cg_build part, not the cgmodel part.
  - [ ] Add in the Rosetta exception scheme for the customNonbondedForce - not sure if this would ever be used

## Questions
- [ ] Should there be a default value of 0 for binary interaction parameter set in cgmodel?
- [ ] Along similar lines, should we always use the customNonbondedForce to make things more consistent?
- [ ] How should be go about generalizing to n particle types? Maybe using interaction groups?

## Status
- [ ] Ready to go