### PR TITLE
fix documentation links to functions

### DIFF
--- a/docs/build.rst
+++ b/docs/build.rst
@@ -1,7 +1,9 @@
 Build module
 ============
 
-.. autosummary::
-    :toctree: api/generated/
+.. currentmodule:: cg_openmm.build
 
-    cg_openmm.build.cg_build
+.. autosummary::
+   :toctree: api/generated/
+   
+   cg_build

--- a/docs/cgmodel.rst
+++ b/docs/cgmodel.rst
@@ -2,6 +2,6 @@ CGModel class
 =========================================================
 
 .. autoclass:: cg_openmm.cg_model.cgmodel.CGModel
-    :members:
+   :members:
     
-    .. automethod:: __init__
+   .. automethod:: __init__

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,7 +15,7 @@
 # Incase the project was not installed
 import os
 import sys
-sys.path.insert(0, os.path.abspath('..'))
+sys.path.insert(0, os.path.abspath('../cg_openmm/'))
 
 import cg_openmm
 

--- a/docs/ensembles.rst
+++ b/docs/ensembles.rst
@@ -1,7 +1,9 @@
 Ensembles module
 ================
 
-.. autosummary::
-    :toctree: api/generated/
+.. currentmodule:: cg_openmm.ensembles
 
-    cg_openmm.ensembles.ens_build
+.. autosummary::
+   :toctree: api/generated/
+
+   ens_build

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -22,7 +22,7 @@ you will also need to install ``analyze_foldamers``, available through GitHub:
 
 In the base directory of ``analyze_foldamers``, install using:
 
-``python setup.py install
+``python setup.py install``
 
 Conda environment
 -----------------
@@ -30,8 +30,9 @@ Conda environment
 ``cg_openmm`` is currently tested and maintained on python 3.6, 3.7, and 3.8.
 
 Create an anaconda environment for running cg_openmm by specifying the following dependencies:
-``conda create -n cg_openmm_env python=3.X mdtraj mpi4py numpy openmm openmmtools physical_validation pymbar
-scikit-learn scipy``
+.. code-block:: bash
+    conda create -n cg_openmm_env python=3.X mdtraj mpi4py numpy openmm openmmtools physical_validation pymbar
+    scikit-learn scipy``
 
 Alternatively, an environment can be created from one of the .yml files provided with ``cg_openmm``.
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -30,9 +30,11 @@ Conda environment
 ``cg_openmm`` is currently tested and maintained on python 3.6, 3.7, and 3.8.
 
 Create an anaconda environment for running cg_openmm by specifying the following dependencies:
+
 .. code-block:: bash
-    conda create -n cg_openmm_env python=3.X mdtraj mpi4py numpy openmm openmmtools physical_validation pymbar
-    scikit-learn scipy``
+    
+   conda create -n cg_openmm_env python=3.X mdtraj mpi4py numpy openmm openmmtools physical_validation
+   pymbar scikit-learn scipy
 
 Alternatively, an environment can be created from one of the .yml files provided with ``cg_openmm``.
 

--- a/docs/parameters.rst
+++ b/docs/parameters.rst
@@ -1,10 +1,12 @@
 Parameters module
 =================
 
-.. autosummary::
-    :toctree: api/generated/
+.. currentmodule:: cg_openmm.parameters
 
-    cg_openmm.parameters.free_energy
-    cg_openmm.parameters.optimize
-    cg_openmm.parameters.reweight
-    cg_openmm.parameters.secondary_structure
+.. autosummary::
+   :toctree: api/generated/
+
+   free_energy
+   optimize
+   reweight
+   secondary_structure

--- a/docs/simulation.rst
+++ b/docs/simulation.rst
@@ -1,9 +1,11 @@
 Simulation module
 =================
 
-.. autosummary::
-    :toctree: api/generated/
+.. currentmodule:: cg_openmm.simulation
 
-    cg_openmm.simulation.physical_validation
-    cg_openmm.simulation.rep_exch
-    cg_openmm.simulation.tools
+.. autosummary::
+   :toctree: api/generated/
+
+   physical_validation
+   rep_exch
+   tools

--- a/docs/submodules/build.cg_build.rst
+++ b/docs/submodules/build.cg_build.rst
@@ -1,0 +1,5 @@
+build.cg_build submodule
+========================================
+
+.. automodule:: cg_openmm.build.cg_build
+   :members:

--- a/docs/submodules/ensembles.ens_build.rst
+++ b/docs/submodules/ensembles.ens_build.rst
@@ -1,0 +1,5 @@
+ensembles.ens_build submodule
+========================================
+
+.. automodule:: cg_openmm.ensembles.ens_build
+   :members:

--- a/docs/submodules/parameters.free_energy.rst
+++ b/docs/submodules/parameters.free_energy.rst
@@ -1,0 +1,5 @@
+parameters.free_energy submodule
+================================
+
+.. automodule:: cg_openmm.parameters.free_energy
+   :members:

--- a/docs/submodules/parameters.optimize.rst
+++ b/docs/submodules/parameters.optimize.rst
@@ -1,0 +1,5 @@
+parameters.optimize submodule
+========================================
+
+.. automodule:: cg_openmm.parameters.optimize
+   :members:

--- a/docs/submodules/parameters.reweight.rst
+++ b/docs/submodules/parameters.reweight.rst
@@ -1,0 +1,5 @@
+parameters.reweight submodule
+========================================
+
+.. automodule:: cg_openmm.parameters.reweight
+   :members:

--- a/docs/submodules/parameters.secondary_structure.rst
+++ b/docs/submodules/parameters.secondary_structure.rst
@@ -1,0 +1,5 @@
+parameters.secondary_structure submodule
+========================================
+
+.. automodule:: cg_openmm.parameters.secondary_structure
+   :members:

--- a/docs/submodules/simulation.physical_validation.rst
+++ b/docs/submodules/simulation.physical_validation.rst
@@ -1,0 +1,5 @@
+simulation.physical_validation submodule
+========================================
+
+.. automodule:: cg_openmm.simulation.physical_validation
+   :members:

--- a/docs/submodules/simulation.rep_exch.rst
+++ b/docs/submodules/simulation.rep_exch.rst
@@ -1,0 +1,5 @@
+simulation.rep_exch submodule
+=============================
+
+.. automodule:: cg_openmm.simulation.rep_exch
+   :members:

--- a/docs/submodules/simulation.tools.rst
+++ b/docs/submodules/simulation.tools.rst
@@ -1,0 +1,5 @@
+simulation.tools submodule
+===========================
+
+.. automodule:: cg_openmm.simulation.tools
+   :members:

--- a/docs/submodules/thermo.calc.rst
+++ b/docs/submodules/thermo.calc.rst
@@ -1,0 +1,5 @@
+thermo.calc submodule
+===========================
+
+.. automodule:: cg_openmm.thermo.calc
+   :members:

--- a/docs/submodules/utilities.iotools.rst
+++ b/docs/submodules/utilities.iotools.rst
@@ -1,0 +1,6 @@
+utilities.iotools submodule
+===========================
+
+.. automodule:: cg_openmm.utilities.iotools
+   :members:
+   

--- a/docs/submodules/utilities.random_builder.rst
+++ b/docs/submodules/utilities.random_builder.rst
@@ -1,0 +1,5 @@
+utilities.iotools submodule
+===========================
+
+.. automodule:: cg_openmm.utilities.random_builder
+   :members:

--- a/docs/submodules/utilities.random_builder.rst
+++ b/docs/submodules/utilities.random_builder.rst
@@ -1,5 +1,5 @@
-utilities.iotools submodule
-===========================
+utilities.random_builder submodule
+==================================
 
 .. automodule:: cg_openmm.utilities.random_builder
    :members:

--- a/docs/submodules/utilities.util.rst
+++ b/docs/submodules/utilities.util.rst
@@ -1,0 +1,5 @@
+utilities.util submodule
+===========================
+
+.. automodule:: cg_openmm.utilities.util
+   :members:

--- a/docs/thermo.rst
+++ b/docs/thermo.rst
@@ -1,7 +1,9 @@
 Thermo module
 =============
 
-.. autosummary::
-    :toctree: api/generated/
+.. currentmodule:: cg_openmm.thermo
 
-    cg_openmm.thermo.calc
+.. autosummary::
+   :toctree: api/generated/
+
+   calc

--- a/docs/utilities.rst
+++ b/docs/utilities.rst
@@ -1,9 +1,11 @@
 Utilities module
 ================
 
-.. autosummary::
-    :toctree: api/generated/
+.. currentmodule:: cg_openmm.utilities
 
-    cg_openmm.utilities.iotools
-    cg_openmm.utilities.random_builder
-    cg_openmm.utilities.util
+.. autosummary::
+   :toctree: api/generated/
+
+   iotools
+   random_builder
+   util


### PR DESCRIPTION
## Description
The previous attempt to get the docs working had the correct summary tables of functions, but the links to the actual function-level documentation were missing.

There are probably better ways of generating this automatically with sphinx templates, but here I created separate .rst files for each submodule, and did 'automodule' for each.