### PR TITLE
dcd support for single temp MD

### DIFF
--- a/cg_openmm/tests/test_simulation.py
+++ b/cg_openmm/tests/test_simulation.py
@@ -129,8 +129,8 @@ def test_set_binary_interaction():
     assert_almost_equal(PE_end_kappa_on,PE_end_kappa_off,decimal=3)
     
     
-def test_run_simulation(tmpdir):
-    """Run a short MD simulation of a 24mer 1b1s model"""
+def test_run_simulation_pdb(tmpdir):
+    """Run a short MD simulation of a 24mer 1b1s model (pdb trajectory output)"""
     
     # Set output directory
     # In pytest we need to use a temp directory
@@ -252,6 +252,7 @@ def test_run_simulation(tmpdir):
         temperature,
         friction=friction,
         print_frequency=print_frequency,
+        output_traj='simulation.pdb',
         output_directory=output_directory,
     )
     
@@ -259,6 +260,137 @@ def test_run_simulation(tmpdir):
     assert os.path.isfile(f"{output_directory}/simulation.pdb")
 
     
+def test_run_simulation_dcd(tmpdir):
+    """Run a short MD simulation of a 24mer 1b1s model (dcd trajectory output)"""
+    
+    # Set output directory
+    # In pytest we need to use a temp directory
+    # tmpdir is a fixture - hence we need to pass it into test function, not import it
+    
+    output_directory = tmpdir.mkdir("output")
+      
+    # OpenMM simulation settings
+    print_frequency = 10  # Number of steps to skip when printing output
+    total_simulation_time = 1.0 * unit.picosecond
+    simulation_time_step = 5.0 * unit.femtosecond
+    total_steps = int(np.floor(total_simulation_time/simulation_time_step))
+    temperature = 200 * unit.kelvin
+    friction = 1.0 / unit.picosecond
+
+    # Coarse grained model settings
+    include_bond_forces = True
+    include_bond_angle_forces = True
+    include_nonbonded_forces = True
+    include_torsion_forces = True
+    constrain_bonds = False
+
+    # Bond definitions
+    bond_length = 1.5 * unit.angstrom
+    bond_lengths = {
+        "bb_bb_bond_length": bond_length,
+        "bb_sc_bond_length": bond_length,
+        "sc_sc_bond_length": bond_length,
+    }
+    bond_force_constant = 1000 * unit.kilojoule_per_mole / unit.nanometer / unit.nanometer
+    bond_force_constants = {
+        "bb_bb_bond_force_constant": bond_force_constant,
+        "bb_sc_bond_force_constant": bond_force_constant,
+        "sc_sc_bond_force_constant": bond_force_constant,
+    }
+
+    # Particle definitions
+    mass = 100.0 * unit.amu
+    r_min = 1.5 * bond_length  # Lennard-Jones potential r_min
+    # Factor of /(2.0**(1/6)) is applied to convert r_min to sigma
+    sigma = r_min / (2.0 ** (1.0 / 6.0))
+    epsilon = 0.5 * unit.kilojoule_per_mole
+    
+    bb = {"particle_type_name": "bb", "sigma": sigma, "epsilon": epsilon, "mass": mass}
+    sc = {"particle_type_name": "sc", "sigma": sigma, "epsilon": epsilon, "mass": mass}
+
+
+    # Bond angle definitions
+    bond_angle_force_constant = 100 * unit.kilojoule_per_mole / unit.radian / unit.radian
+    bond_angle_force_constants = {
+        "bb_bb_bb_bond_angle_force_constant": bond_angle_force_constant,
+        "bb_bb_sc_bond_angle_force_constant": bond_angle_force_constant,
+    }
+    # OpenMM requires angle definitions in units of radians
+    bb_bb_bb_equil_bond_angle = 120.0 * unit.degrees
+    bb_bb_sc_equil_bond_angle = 120.0 * unit.degrees
+    equil_bond_angles = {
+        "bb_bb_bb_equil_bond_angle": bb_bb_bb_equil_bond_angle,
+        "bb_bb_sc_equil_bond_angle": bb_bb_sc_equil_bond_angle,
+    }
+
+    # Torsion angle definitions
+    torsion_force_constant = 20.0 * unit.kilojoule_per_mole
+    torsion_force_constants = {
+        "bb_bb_bb_bb_torsion_force_constant": torsion_force_constant,
+        "bb_bb_bb_sc_torsion_force_constant": torsion_force_constant
+    }
+
+    bb_bb_bb_bb_torsion_phase_angle = 75.0 * unit.degrees
+    bb_bb_bb_sc_torsion_phase_angle = 75.0 * unit.degrees
+
+    torsion_phase_angles = {
+        "bb_bb_bb_bb_torsion_phase_angle": bb_bb_bb_bb_torsion_phase_angle,
+        "bb_bb_bb_sc_torsion_phase_angle": bb_bb_bb_sc_torsion_phase_angle
+    }
+    torsion_periodicities = {
+        "bb_bb_bb_bb_torsion_periodicity": 3,
+        "bb_bb_bb_sc_torsion_periodicity": 3}
+
+    # Monomer definitions
+    A = {
+        "monomer_name": "A",
+        "particle_sequence": [bb, sc],
+        "bond_list": [[0, 1]],
+        "start": 0,
+        "end": 0,
+    }
+    
+    sequence = 24 * [A]
+    
+    pdb_path = os.path.join(structures_path, "24mer_1b1s_initial_structure.pdb")
+    positions = PDBFile(pdb_path).getPositions()
+    
+    # Build a coarse grained model
+    cgmodel = CGModel(
+        particle_type_list=[bb, sc],
+        bond_lengths=bond_lengths,
+        bond_force_constants=bond_force_constants,
+        bond_angle_force_constants=bond_angle_force_constants,
+        torsion_force_constants=torsion_force_constants,
+        equil_bond_angles=equil_bond_angles,
+        torsion_phase_angles=torsion_phase_angles,
+        torsion_periodicities=torsion_periodicities,
+        include_nonbonded_forces=include_nonbonded_forces,
+        include_bond_forces=include_bond_forces,
+        include_bond_angle_forces=include_bond_angle_forces,
+        include_torsion_forces=include_torsion_forces,
+        constrain_bonds=constrain_bonds,
+        positions=positions,
+        sequence=sequence,
+        monomer_types=[A],
+    )    
+    
+    
+    run_simulation(
+        cgmodel,
+        total_simulation_time,
+        simulation_time_step,
+        temperature,
+        friction=friction,
+        print_frequency=print_frequency,
+        output_traj='simulation.dcd',
+        output_directory=output_directory,
+    )
+    
+    assert os.path.isfile(f"{output_directory}/simulation.dat")
+    assert os.path.isfile(f"{output_directory}/simulation.dcd")    
+
+
 def test_run_replica_exchange(tmpdir):
     """
     Run a short replica exchange MD simulation of a 24mer 1b1s model


### PR DESCRIPTION
## Description
Add the option of using OpenMM dcd reporter instead of pdb reporter for the single temp standard MD simulations (much smaller files for long runs).

## Status
- [x] Ready to go