### PR TITLE
Restarting / extending replica exchange simulations

### DIFF
--- a/cg_openmm/simulation/rep_exch.py
+++ b/cg_openmm/simulation/rep_exch.py
@@ -786,8 +786,9 @@ def run_replica_exchange(
     if minimize:
         simulation.minimize()
 
-    print("Running replica exchange simulations with OpenMM...")
-    print(f"Using a time step of {simulation_time_step}")
+    print("Running OpenMM replica exchange simulation...")
+    print(f"Time step: {simulation_time_step}")
+    print(f"Iterations: {exchange_attempts}")
     try:
         simulation.run()
     except BaseException:

--- a/cg_openmm/tests/test_simulation.py
+++ b/cg_openmm/tests/test_simulation.py
@@ -19,7 +19,6 @@ from cg_openmm.utilities import random_builder
 from cg_openmm.build.cg_build import build_topology
 import numpy as np
 from numpy.testing import assert_almost_equal
-from openmmtools.cache import global_context_cache
 import pickle
 
 def test_cg_openmm_imported():
@@ -397,8 +396,6 @@ def test_run_replica_exchange(tmpdir):
     Test replica exchange processing (write pdb files)
     """
 
-    global_context_cache.platform = openmm.Platform.getPlatformByName("CPU")
-    
     # Set output directory
     # In pytest we need to use a temp directory
     # tmpdir is a fixture - hence we need to pass it into test function, not import it
@@ -641,8 +638,6 @@ def test_restart_replica_exchange(tmpdir):
     Test heat capacity analysis code
     Test physical validation code
     """
-
-    global_context_cache.platform = openmm.Platform.getPlatformByName("CPU")
     
     # Set output directory
     # In pytest we need to use a temp directory

--- a/cg_openmm/tests/test_simulation.py
+++ b/cg_openmm/tests/test_simulation.py
@@ -656,6 +656,8 @@ def test_restart_replica_exchange(tmpdir):
     temperature_list = get_temperature_list(min_temp, max_temp, number_replicas)
     exchange_frequency = 10  # Number of steps between exchange attempts
     
+    exchange_attempts = int(np.floor(total_steps/exchange_frequency))
+    
     # Coarse grained model settings
     include_bond_forces = True
     include_bond_angle_forces = True
@@ -780,5 +782,5 @@ def test_restart_replica_exchange(tmpdir):
         output_directory=output_directory,
     )
     
-    assert replica_energies.shape[1] == (total_steps*2 + 1) 
-        
+    assert replica_energies.shape[2] == (exchange_attempts*2 + 1)
+    


### PR DESCRIPTION
## Description
This PR adds a function for adding additional steps to a replica exchange simulation that has already finished. Actually it is quite simple using the simulation.extend() function in openmmtools. (see here: https://openmmtools.readthedocs.io/en/0.18.1/api/generated/openmmtools.multistate.ReplicaExchangeSampler.html?highlight=extend#openmmtools.multistate.ReplicaExchangeSampler.extend)

This new function restart_replica_exchange reads the existing .nc file, and continues the simulation for a specified number of exchange attempts.

As for post-processing, we should be able to just rerun process_replica_exchange_data on the updated .nc files.

## Status
- [x] Ready to go