### PR TITLE
function for binary sequence FWHM eval

### DIFF
--- a/cg_openmm/cg_model/cgmodel.py
+++ b/cg_openmm/cg_model/cgmodel.py
@@ -658,8 +658,7 @@ class CGModel(object):
                 for exclusion in exclusion_list:
                     if exclusion in interaction_list:
                         interaction_list.remove(exclusion)
-                    if [exclusion[1], exclusion[0]] in exclusion_list:
-                        print([exclusion[1], exclusion[0]])
+                    if [exclusion[1], exclusion[0]] in interaction_list:
                         interaction_list.remove([exclusion[1], exclusion[0]])
         else:
             for particle_1 in range(self.num_beads):

--- a/cg_openmm/parameters/evaluate_energy.py
+++ b/cg_openmm/parameters/evaluate_energy.py
@@ -666,7 +666,7 @@ def eval_energy(cgmodel, file_list, temperature_list, param_dict,
 
 
 def eval_energy_sequences(cgmodel, file_list, temperature_list, monomer_list, sequence=None,
-    output_data='output/output.nc', num_intermediate_states=3, n_trial_boot=200, plot_dir='output',
+    output_data='output/output.nc', num_intermediate_states=3, n_trial_boot=200, plot_dir='',
     frame_begin=0, frame_end=-1, sample_spacing=1, sparsify_stride=1, verbose=False, n_cpu=1):
     """
     Given a cgmodel with a topology and system, evaluate the energy at all structures in each
@@ -698,8 +698,8 @@ def eval_energy_sequences(cgmodel, file_list, temperature_list, monomer_list, se
     :param n_trial_boot: number of trials to run for generating bootstrapping uncertainties. If None, a single heat capacity calculation will be performed. (default=200)
     :type n_trial_boot: int
     
-    :param plot_dir: path to directory to which plot files will be saved
-    type plot_dir: str
+    :param plot_dir: path to directory to which plot files will be saved (default='')
+    :type plot_dir: str
 
     :param frame_begin: analyze starting from this frame, discarding all prior as equilibration period (default=0)
     :type frame_begin: int
@@ -899,7 +899,7 @@ def eval_energy_sequences(cgmodel, file_list, temperature_list, monomer_list, se
                     seq_unique.append(seq_int)
                 else:
                     # Use integer sequence
-                    seq_unique.append(sequence)
+                    seq_unique.append(seq)
         elif type(sequence[0]) == dict:
             seq_int = []
             # Convert monomer dict to integers
@@ -975,6 +975,21 @@ def eval_energy_sequences(cgmodel, file_list, temperature_list, monomer_list, se
             
         if verbose:
             print(f'Evaluating sequence: {seq_print}')  
+            
+        # Set the heat capacity plot path:
+        if plot_dir == None:
+            # Don't create plot:
+            plot_file_reeval = None
+        elif plot_dir == '' or plot_dir == ' ':
+            # Use the current working directory:
+            plot_file_reeval = f"heat_capacity_{seq_print}.pdf"
+        else:
+            # Use the specified plot directory:
+            if os.path.isdir(plot_dir):
+                pass
+            else:
+                os.mkdir(plot_dir)
+            plot_file_reeval = f"{plot_dir}/heat_capacity_{seq_print}.pdf"
         
         # Get residue types of nonbonded pairs:
         res_types = np.zeros((len(res_id_pairs),2))
@@ -1033,7 +1048,7 @@ def eval_energy_sequences(cgmodel, file_list, temperature_list, monomer_list, se
                 frame_end=frame_end,
                 sample_spacing=int(sample_spacing*sparsify_stride),
                 num_intermediate_states=num_intermediate_states,
-                plot_file_reeval=f"{plot_dir}/heat_capacity_{seq_print}.pdf",
+                plot_file_reeval=plot_file_reeval,
                 plot_file_sim=None,
             )
             
@@ -1056,7 +1071,7 @@ def eval_energy_sequences(cgmodel, file_list, temperature_list, monomer_list, se
                 sparsify_stride=sparsify_stride,
                 n_trial_boot=n_trial_boot,
                 num_intermediate_states=num_intermediate_states,
-                plot_file=f"{plot_dir}/heat_capacity_{seq_print}.pdf",
+                plot_file=plot_file_reeval,
             )
         
         seq_time_cv_done = time.perf_counter()

--- a/cg_openmm/parameters/evaluate_energy.py
+++ b/cg_openmm/parameters/evaluate_energy.py
@@ -619,11 +619,6 @@ def eval_energy(cgmodel, file_list, temperature_list, param_dict,
                                     print(f'Force constant: {k_old} --> {param_kt_curr.in_units_of(k_old.unit)}')
 
                     torsion_index += 1
-                    
-                # n_torsion_forces_new = force.getNumTorsions()
-                # if verbose:
-                    # print(f'\nOld total number of torsion force terms: {n_torsion_forces}')
-                    # print(f'New total number of torsion force terms: {n_torsion_forces_new}')
 
     # Update the positions and evaluate all specified frames:
     # Run with multiple processors and gather data from all replicas:       
@@ -876,7 +871,6 @@ def eval_energy_sequences(cgmodel, file_list, temperature_list, monomer_list, se
         
         elif len(monomer_list) == 2:
             for seq in list(product([0,1],repeat=num_monomers)):
-                #***reversed(seq) returns a reverse iterator object here. Does this work?
                 if seq not in seq_unique and tuple(reversed(seq)) not in seq_unique: # No reverse duplicates
                     # Compute new nonbonded energies
                     seq_unique.append(seq)
@@ -901,7 +895,6 @@ def eval_energy_sequences(cgmodel, file_list, temperature_list, monomer_list, se
                                 break
                             else:
                                 i += 1
-                    print(seq_int)
                     seq_unique.append(seq_int)
                 else:
                     # Use integer sequence
@@ -917,7 +910,6 @@ def eval_energy_sequences(cgmodel, file_list, temperature_list, monomer_list, se
                         break
                     else:
                         i += 1
-            print(seq_int)
             seq_unique.append(seq_int)
         
         elif type(sequence[0]) == int:
@@ -971,8 +963,17 @@ def eval_energy_sequences(cgmodel, file_list, temperature_list, monomer_list, se
     
     for seq in seq_unique:
         seq_time_start = time.perf_counter()
+        
+        # Format the sequence for printing:
+        seq_print = str(seq).replace(',','')
+        seq_print = seq_print.replace(' ','')
+        seq_print = seq_print.replace('[','')
+        seq_print = seq_print.replace(']','')
+        for s in range(len(monomer_list)):
+            seq_print = seq_print.replace(str(s),monomer_list[s]["monomer_name"])
+            
         if verbose:
-            print(f'seq: {seq}')  
+            print(f'Evaluating sequence: {seq_print}')  
         
         # Get residue types of nonbonded pairs:
         res_types = np.zeros((len(res_id_pairs),2))
@@ -1016,14 +1017,6 @@ def eval_energy_sequences(cgmodel, file_list, temperature_list, monomer_list, se
         seq_time_energies_done = time.perf_counter()
         if verbose:
             print(f'nonbonded eval done ({seq_time_energies_done-seq_time_start:.4f} s)')
-
-        # Format the sequence for printing:
-        seq_print = str(seq).replace(',','')
-        seq_print = seq_print.replace(' ','')
-        seq_print = seq_print.replace('[','')
-        seq_print = seq_print.replace(']','')
-        for s in range(len(monomer_list)):
-            seq_print = seq_print.replace(str(s),monomer_list[s]["monomer_name"])
         
         # Now, evaluate the FWHM
         if n_trial_boot is None:

--- a/cg_openmm/parameters/secondary_structure.py
+++ b/cg_openmm/parameters/secondary_structure.py
@@ -51,13 +51,24 @@ def get_native_contacts(cgmodel, native_structure_file, native_contact_distance_
         
     # Include only pairs contained in the nonbonded_interaction_list    
     nonbonded_interaction_list = cgmodel.nonbonded_interaction_list
-    native_structure_distances = distances(nonbonded_interaction_list, native_structure)
+    nonbonded_exclusion_list = cgmodel.get_nonbonded_exclusion_list()
+    
+    # Determine the true nonbonded inclusion list
+    nonbonded_inclusion_list = []
+    
+    for pair in nonbonded_interaction_list:
+        par1 = pair[0]
+        par2 = pair[1]
+        if [par1,par2] not in nonbonded_exclusion_list and [par2,par1] not in nonbonded_exclusion_list:
+            nonbonded_inclusion_list.append(pair)
+                
+    native_structure_distances = distances(nonbonded_inclusion_list, native_structure)
     native_contact_list = []
     native_contact_distances_list = []
     
-    for interaction in range(len(nonbonded_interaction_list)):
+    for interaction in range(len(nonbonded_inclusion_list)):
         if native_structure_distances[interaction] < (native_contact_distance_cutoff):
-            native_contact_list.append(nonbonded_interaction_list[interaction])
+            native_contact_list.append(nonbonded_inclusion_list[interaction])
             native_contact_distances_list.append(distances(native_contact_list, native_structure))
     
     # Units get messed up if converted using np.asarray

--- a/cg_openmm/tests/test_cgmodel.py
+++ b/cg_openmm/tests/test_cgmodel.py
@@ -150,7 +150,7 @@ def test_get_bond_list(create_cgmodel):
 def test_get_nonbonded_interaction_list(create_cgmodel):
     cgmodel = create_cgmodel
     nonbond_list = cgmodel.get_nonbonded_interaction_list()
-    assert len(nonbond_list) == 1081
+    assert len(nonbond_list) == 1013
     
 
 def test_get_nonbonded_exclusion_list(create_cgmodel):

--- a/cg_openmm/tests/test_energy_eval.py
+++ b/cg_openmm/tests/test_energy_eval.py
@@ -5,9 +5,10 @@ Unit and regression test for the cg_openmm package.
 # Import package, test suite, and other packages as needed  
   
 import os
+import copy
 from simtk import unit
 from cg_openmm.cg_model.cgmodel import CGModel
-from cg_openmm.parameters.evaluate_energy import eval_energy
+from cg_openmm.parameters.evaluate_energy import *
 from cg_openmm.thermo.calc import *
 from cg_openmm.parameters.reweight import get_temperature_list, get_opt_temperature_list
 from openmmtools.multistate import MultiStateReporter
@@ -1378,6 +1379,187 @@ def test_reeval_heat_capacity_boot_end_frame(tmpdir):
     
     assert os.path.isfile(f"{output_directory}/heat_capacity_reeval_boot.pdf")
     
+
+def test_eval_FWHM_sequences_no_change_1(tmpdir):
+    """
+    Test sequence energy/heat capacity evaluation code, with no changes made to the sequence,
+    checking that heat capacity curve matches the original reference simulation.
+    Sequence is single list of monomer dicts.
+    Single heat capacity calculation (no bootstrapping)
+    """
+    output_directory = tmpdir.mkdir("output")    
+    
+    # Replica exchange settings
+    number_replicas = 12
+    min_temp = 200.0 * unit.kelvin
+    max_temp = 600.0 * unit.kelvin
+    temperature_list = get_temperature_list(min_temp, max_temp, number_replicas)
+    
+    # Load in cgmodel
+    cgmodel = pickle.load(open(f"{data_path}/stored_cgmodel.pkl", "rb" ))
+    
+    # Data file with simulated energies:
+    output_data = os.path.join(data_path, "output.nc")
+    
+    # Create list of replica trajectories to analyze
+    dcd_file_list = []
+    for i in range(len(temperature_list)):
+        dcd_file_list.append(f"{data_path}/replica_{i+1}.dcd")
+    
+    # Set up monomer dictionaries:
+    A = cgmodel.monomer_types[0]
+    # sigma_bb = 2.25 A
+    # epsilon_bb = 1.5 kJ/mol
+    # sigma_sc = 3.5 A
+    # epsilon_sc = 5.0 kJ/mol
+    
+    B = copy.deepcopy(A)
+    # A and B need separate names:
+    B["monomer_name"] = "B"
+
+    monomer_list = [A,B]
+    
+    nmono = len(cgmodel.sequence)
+    
+    sequence = []
+    for i in range(int(nmono/2)):
+        sequence.append(A)
+        sequence.append(B)
+
+    frame_begin = 100
+    frame_end = 150
+    sample_spacing = 1
+    sparsify_stride = 1
+    num_intermediate_states = 1
+
+    # Re-evaluate OpenMM energies:
+    (seq_FWHM, seq_FWHM_uncertainty,
+    seq_Cv, seq_Cv_uncertainty, seq_N_eff) = eval_energy_sequences(
+        cgmodel,
+        dcd_file_list,
+        temperature_list,
+        monomer_list=monomer_list,
+        sequence=sequence,
+        num_intermediate_states=num_intermediate_states,
+        n_trial_boot=None,
+        plot_dir=output_directory,
+        output_data=output_data,
+        frame_begin=frame_begin,
+        frame_end=frame_end,
+        sample_spacing=sample_spacing,
+        sparsify_stride=sparsify_stride,
+        verbose=True,
+        n_cpu=1,
+    )
+    for key, value in seq_Cv.items():
+        seq_Cv_array = value
+    
+    # Get heat capacity from original dataset:
+    (Cv_ref, dCv_ref, temperature_list_ref,
+    FWHM_ref, Tm_ref, Cv_height_ref, N_eff_ref) = get_heat_capacity(
+        frame_begin=frame_begin,
+        frame_end=frame_end,
+        sample_spacing=int(sample_spacing*sparsify_stride),
+        output_data=output_data,
+        num_intermediate_states=num_intermediate_states,
+        plot_file=f"{output_directory}/heat_capacity_ref.pdf"
+    )
+    
+    seq_Cv_array = seq_Cv_array.value_in_unit(unit.kilojoule_per_mole/unit.kelvin)
+    Cv_ref = Cv_ref.value_in_unit(unit.kilojoule_per_mole/unit.kelvin)
+    
+    assert_allclose(seq_Cv_array, Cv_ref,atol=1E-4)
     
     
+def test_eval_FWHM_sequences_no_change_2(tmpdir):
+    """
+    Test sequence energy/heat capacity evaluation code, with no changes made to the sequence,
+    checking that heat capacity curve matches the original reference simulation.
+    Sequence is single list of integers corresponding to indices in monomer_list.
+    Single heat capacity calculation (no bootstrapping)
+    Sparsify stride is applied to evaluate energies of fewer frames.
+    """
+    output_directory = tmpdir.mkdir("output")    
+    
+    # Replica exchange settings
+    number_replicas = 12
+    min_temp = 200.0 * unit.kelvin
+    max_temp = 600.0 * unit.kelvin
+    temperature_list = get_temperature_list(min_temp, max_temp, number_replicas)
+    
+    # Load in cgmodel
+    cgmodel = pickle.load(open(f"{data_path}/stored_cgmodel.pkl", "rb" ))
+    
+    # Data file with simulated energies:
+    output_data = os.path.join(data_path, "output.nc")
+    
+    # Create list of replica trajectories to analyze
+    dcd_file_list = []
+    for i in range(len(temperature_list)):
+        dcd_file_list.append(f"{data_path}/replica_{i+1}.dcd")
+    
+    # Set up monomer dictionaries:
+    A = cgmodel.monomer_types[0]
+    # sigma_bb = 2.25 A
+    # epsilon_bb = 1.5 kJ/mol
+    # sigma_sc = 3.5 A
+    # epsilon_sc = 5.0 kJ/mol
+    
+    B = copy.deepcopy(A)
+    # A and B need separate names:
+    B["monomer_name"] = "B"
+
+    monomer_list = [A,B]
+    
+    nmono = len(cgmodel.sequence)
+    
+    sequence = []
+    for i in range(int(nmono/2)):
+        sequence.append(0)
+        sequence.append(1)
+
+    frame_begin = 100
+    frame_end = 150
+    sample_spacing = 1
+    sparsify_stride = 3
+    num_intermediate_states = 1
+
+    # Re-evaluate OpenMM energies:
+    (seq_FWHM, seq_FWHM_uncertainty,
+    seq_Cv, seq_Cv_uncertainty, seq_N_eff) = eval_energy_sequences(
+        cgmodel,
+        dcd_file_list,
+        temperature_list,
+        monomer_list=monomer_list,
+        sequence=sequence,
+        num_intermediate_states=num_intermediate_states,
+        n_trial_boot=None,
+        plot_dir=output_directory,
+        output_data=output_data,
+        frame_begin=frame_begin,
+        frame_end=frame_end,
+        sample_spacing=sample_spacing,
+        sparsify_stride=sparsify_stride,
+        verbose=True,
+        n_cpu=1,
+    )
+    for key, value in seq_Cv.items():
+        seq_Cv_array = value
+    
+    # Get heat capacity from original dataset:
+    (Cv_ref, dCv_ref, temperature_list_ref,
+    FWHM_ref, Tm_ref, Cv_height_ref, N_eff_ref) = get_heat_capacity(
+        frame_begin=frame_begin,
+        frame_end=frame_end,
+        sample_spacing=int(sample_spacing*sparsify_stride),
+        output_data=output_data,
+        num_intermediate_states=num_intermediate_states,
+        plot_file=f"{output_directory}/heat_capacity_ref.pdf"
+    )
+    
+    seq_Cv_array = seq_Cv_array.value_in_unit(unit.kilojoule_per_mole/unit.kelvin)
+    Cv_ref = Cv_ref.value_in_unit(unit.kilojoule_per_mole/unit.kelvin)
+    
+    assert_allclose(seq_Cv_array, Cv_ref,atol=1E-4)
+        
     

--- a/cg_openmm/tests/test_energy_eval.py
+++ b/cg_openmm/tests/test_energy_eval.py
@@ -46,13 +46,15 @@ def test_eval_energy_no_change(tmpdir):
     param_dict = {}
     param_dict['bb_epsilon'] = 1.5 * unit.kilojoule_per_mole # Was 1.5 kJ/mol previously
     
+    frame_begin = 100
+    
     # Re-evaluate OpenMM energies:
     U_eval, simulation = eval_energy(
         cgmodel,
         dcd_file_list,
         temperature_list,
         param_dict,
-        frame_begin=0,
+        frame_begin=frame_begin,
         frame_end=-1,
         frame_stride=1,
         verbose=True,
@@ -71,7 +73,7 @@ def test_eval_energy_no_change(tmpdir):
     ) = analyzer.read_energies()    
     
     # Rounding error with stored positions and/or energies is on the order of 1E-4
-    assert_allclose(U_eval,replica_energies,atol=1E-3)
+    assert_allclose(U_eval,replica_energies[:,:,frame_begin::],atol=1E-3)
     
     
 def test_eval_energy_no_change_parallel(tmpdir):  
@@ -100,13 +102,15 @@ def test_eval_energy_no_change_parallel(tmpdir):
     param_dict = {}
     param_dict['bb_epsilon'] = 1.5 * unit.kilojoule_per_mole # Was 1.5 kJ/mol previously
     
+    frame_begin = 100
+    
     # Re-evaluate OpenMM energies:
     U_eval, simulation = eval_energy(
         cgmodel,
         dcd_file_list,
         temperature_list,
         param_dict,
-        frame_begin=0,
+        frame_begin=frame_begin,
         frame_end=-1,
         frame_stride=1,
         verbose=True,
@@ -126,7 +130,7 @@ def test_eval_energy_no_change_parallel(tmpdir):
     ) = analyzer.read_energies()    
     
     # Rounding error with stored positions and/or energies is on the order of 1E-4
-    assert_allclose(U_eval,replica_energies,atol=1E-3)
+    assert_allclose(U_eval,replica_energies[:,:,frame_begin::],atol=1E-3)
     
     
 def test_eval_energy_new_sigma(tmpdir):  
@@ -161,7 +165,7 @@ def test_eval_energy_new_sigma(tmpdir):
         dcd_file_list,
         temperature_list,
         param_dict,
-        frame_begin=0,
+        frame_begin=100,
         frame_end=-1,
         frame_stride=5,
         verbose=True,
@@ -209,7 +213,7 @@ def test_eval_energy_new_epsilon(tmpdir):
         dcd_file_list,
         temperature_list,
         param_dict,
-        frame_begin=0,
+        frame_begin=100,
         frame_end=-1,
         frame_stride=5,
         verbose=True,
@@ -260,7 +264,7 @@ def test_eval_energy_new_bond_length(tmpdir):
         dcd_file_list,
         temperature_list,
         param_dict,
-        frame_begin=0,
+        frame_begin=100,
         frame_end=-1,
         frame_stride=5,
         verbose=True,
@@ -288,7 +292,7 @@ def test_eval_energy_new_bond_length(tmpdir):
         dcd_file_list,
         temperature_list,
         param_dict_rev,
-        frame_begin=0,
+        frame_begin=100,
         frame_end=-1,
         frame_stride=5,
         verbose=True,
@@ -337,7 +341,7 @@ def test_eval_energy_new_bond_k(tmpdir):
         dcd_file_list,
         temperature_list,
         param_dict,
-        frame_begin=0,
+        frame_begin=100,
         frame_end=-1,
         frame_stride=5,
         verbose=True,
@@ -363,7 +367,7 @@ def test_eval_energy_new_bond_k(tmpdir):
         dcd_file_list,
         temperature_list,
         param_dict_rev,
-        frame_begin=0,
+        frame_begin=100,
         frame_end=-1,
         frame_stride=5,
         verbose=True,
@@ -413,7 +417,7 @@ def test_eval_energy_new_angle_val(tmpdir):
         dcd_file_list,
         temperature_list,
         param_dict,
-        frame_begin=0,
+        frame_begin=100,
         frame_end=-1,
         frame_stride=5,
         verbose=True,
@@ -439,7 +443,7 @@ def test_eval_energy_new_angle_val(tmpdir):
         dcd_file_list,
         temperature_list,
         param_dict_rev,
-        frame_begin=0,
+        frame_begin=100,
         frame_end=-1,
         frame_stride=5,
         verbose=True,
@@ -488,7 +492,7 @@ def test_eval_energy_new_angle_k(tmpdir):
         dcd_file_list,
         temperature_list,
         param_dict,
-        frame_begin=0,
+        frame_begin=100,
         frame_end=-1,
         frame_stride=5,
         verbose=True,
@@ -514,7 +518,7 @@ def test_eval_energy_new_angle_k(tmpdir):
         dcd_file_list,
         temperature_list,
         param_dict_rev,
-        frame_begin=0,
+        frame_begin=100,
         frame_end=-1,
         frame_stride=5,
         verbose=True,
@@ -566,7 +570,7 @@ def test_eval_energy_new_torsion_val(tmpdir):
         dcd_file_list,
         temperature_list,
         param_dict,
-        frame_begin=0,
+        frame_begin=100,
         frame_end=-1,
         frame_stride=5,
         verbose=True,
@@ -594,7 +598,7 @@ def test_eval_energy_new_torsion_val(tmpdir):
         dcd_file_list,
         temperature_list,
         param_dict_rev,
-        frame_begin=0,
+        frame_begin=100,
         frame_end=-1,
         frame_stride=5,
         verbose=True,
@@ -645,7 +649,7 @@ def test_eval_energy_new_torsion_k(tmpdir):
         dcd_file_list,
         temperature_list,
         param_dict,
-        frame_begin=0,
+        frame_begin=100,
         frame_end=-1,
         frame_stride=5,
         verbose=True,
@@ -673,7 +677,7 @@ def test_eval_energy_new_torsion_k(tmpdir):
         dcd_file_list,
         temperature_list,
         param_dict_rev,
-        frame_begin=0,
+        frame_begin=100,
         frame_end=-1,
         frame_stride=5,
         verbose=True,
@@ -724,7 +728,7 @@ def test_eval_energy_new_torsion_periodicity(tmpdir):
         dcd_file_list,
         temperature_list,
         param_dict,
-        frame_begin=0,
+        frame_begin=100,
         frame_end=-1,
         frame_stride=5,
         verbose=True,
@@ -752,7 +756,7 @@ def test_eval_energy_new_torsion_periodicity(tmpdir):
         dcd_file_list,
         temperature_list,
         param_dict_rev,
-        frame_begin=0,
+        frame_begin=100,
         frame_end=-1,
         frame_stride=5,
         verbose=True,
@@ -814,7 +818,7 @@ def test_eval_energy_sums_periodic_torsion_1(tmpdir):
         dcd_file_list,
         temperature_list,
         param_dict,
-        frame_begin=0,
+        frame_begin=100,
         frame_end=-1,
         frame_stride=5,
         verbose=True,
@@ -869,7 +873,7 @@ def test_eval_energy_sums_periodic_torsion_2(tmpdir):
         dcd_file_list,
         temperature_list,
         param_dict,
-        frame_begin=0,
+        frame_begin=100,
         frame_end=-1,
         frame_stride=5,
         verbose=True,
@@ -924,7 +928,7 @@ def test_eval_energy_sums_periodic_torsion_3(tmpdir):
         dcd_file_list,
         temperature_list,
         param_dict,
-        frame_begin=0,
+        frame_begin=100,
         frame_end=-1,
         frame_stride=5,
         verbose=True,
@@ -1001,7 +1005,7 @@ def test_eval_energy_all_parameters(tmpdir):
         dcd_file_list,
         temperature_list,
         param_dict,
-        frame_begin=0,
+        frame_begin=100,
         frame_end=-1,
         frame_stride=5,
         verbose=True,
@@ -1382,7 +1386,7 @@ def test_reeval_heat_capacity_boot_end_frame(tmpdir):
 
 def test_eval_FWHM_sequences_no_change_1(tmpdir):
     """
-    Test sequence energy/heat capacity evaluation code, with no changes made to the sequence,
+    Test sequence energy/heat capacity evaluation code, with no changes made to the monomer types (A homopolymer),
     checking that heat capacity curve matches the original reference simulation.
     Sequence is single list of monomer dicts.
     Single heat capacity calculation (no bootstrapping)
@@ -1412,19 +1416,14 @@ def test_eval_FWHM_sequences_no_change_1(tmpdir):
     # epsilon_bb = 1.5 kJ/mol
     # sigma_sc = 3.5 A
     # epsilon_sc = 5.0 kJ/mol
-    
-    B = copy.deepcopy(A)
-    # A and B need separate names:
-    B["monomer_name"] = "B"
 
-    monomer_list = [A,B]
+    monomer_list = [A]
     
     nmono = len(cgmodel.sequence)
     
     sequence = []
-    for i in range(int(nmono/2)):
+    for i in range(int(nmono)):
         sequence.append(A)
-        sequence.append(B)
 
     frame_begin = 100
     frame_end = 150
@@ -1473,7 +1472,7 @@ def test_eval_FWHM_sequences_no_change_1(tmpdir):
     
 def test_eval_FWHM_sequences_no_change_2(tmpdir):
     """
-    Test sequence energy/heat capacity evaluation code, with no changes made to the sequence,
+    Test sequence energy/heat capacity evaluation code, with no changes made to the monomer types (AB alt),
     checking that heat capacity curve matches the original reference simulation.
     Sequence is single list of integers corresponding to indices in monomer_list.
     Single heat capacity calculation (no bootstrapping)
@@ -1520,7 +1519,7 @@ def test_eval_FWHM_sequences_no_change_2(tmpdir):
 
     frame_begin = 100
     frame_end = 150
-    sample_spacing = 1
+    sample_spacing = 6
     sparsify_stride = 3
     num_intermediate_states = 1
 
@@ -1563,3 +1562,342 @@ def test_eval_FWHM_sequences_no_change_2(tmpdir):
     assert_allclose(seq_Cv_array, Cv_ref,atol=1E-4)
         
     
+def test_eval_FWHM_boot_sequences_no_change_1(tmpdir):
+    """
+    Test sequence energy/heat capacity evaluation code, with no changes made to the monomer types (A homopolymer).
+    Sequence is single list of monomer dicts.
+    Bootstrapping heat capacity calculation.
+    """
+    output_directory = tmpdir.mkdir("output")    
+    
+    # Replica exchange settings
+    number_replicas = 12
+    min_temp = 200.0 * unit.kelvin
+    max_temp = 600.0 * unit.kelvin
+    temperature_list = get_temperature_list(min_temp, max_temp, number_replicas)
+    
+    # Load in cgmodel
+    cgmodel = pickle.load(open(f"{data_path}/stored_cgmodel.pkl", "rb" ))
+    
+    # Data file with simulated energies:
+    output_data = os.path.join(data_path, "output.nc")
+    
+    # Create list of replica trajectories to analyze
+    dcd_file_list = []
+    for i in range(len(temperature_list)):
+        dcd_file_list.append(f"{data_path}/replica_{i+1}.dcd")
+    
+    # Set up monomer dictionaries:
+    A = cgmodel.monomer_types[0]
+    # sigma_bb = 2.25 A
+    # epsilon_bb = 1.5 kJ/mol
+    # sigma_sc = 3.5 A
+    # epsilon_sc = 5.0 kJ/mol
+
+    monomer_list = [A]
+    
+    nmono = len(cgmodel.sequence)
+    
+    sequence = []
+    for i in range(int(nmono)):
+        sequence.append(A)
+
+    frame_begin = 100
+    frame_end = 150
+    sample_spacing = 1
+    sparsify_stride = 1
+    num_intermediate_states = 1
+
+    # Re-evaluate OpenMM energies:
+    (seq_FWHM, seq_FWHM_uncertainty,
+    seq_Cv, seq_Cv_uncertainty, seq_N_eff) = eval_energy_sequences(
+        cgmodel,
+        dcd_file_list,
+        temperature_list,
+        monomer_list=monomer_list,
+        sequence=sequence,
+        num_intermediate_states=num_intermediate_states,
+        n_trial_boot=10,
+        plot_dir=output_directory,
+        output_data=output_data,
+        frame_begin=frame_begin,
+        frame_end=frame_end,
+        sample_spacing=sample_spacing,
+        sparsify_stride=sparsify_stride,
+        verbose=True,
+        n_cpu=1,
+    )
+
+    
+def test_eval_FWHM_boot_sequences_no_change_2(tmpdir):
+    """
+    Test sequence energy/heat capacity evaluation code, with no changes made to the monomer types (AB alt).
+    Sequence is single list of integers corresponding to indices in monomer_list.
+    Bootstrapping heat capacity calculation.
+    Sparsify stride is applied to evaluate energies of fewer frames.
+    """
+    output_directory = tmpdir.mkdir("output")    
+    
+    # Replica exchange settings
+    number_replicas = 12
+    min_temp = 200.0 * unit.kelvin
+    max_temp = 600.0 * unit.kelvin
+    temperature_list = get_temperature_list(min_temp, max_temp, number_replicas)
+    
+    # Load in cgmodel
+    cgmodel = pickle.load(open(f"{data_path}/stored_cgmodel.pkl", "rb" ))
+    
+    # Data file with simulated energies:
+    output_data = os.path.join(data_path, "output.nc")
+    
+    # Create list of replica trajectories to analyze
+    dcd_file_list = []
+    for i in range(len(temperature_list)):
+        dcd_file_list.append(f"{data_path}/replica_{i+1}.dcd")
+    
+    # Set up monomer dictionaries:
+    A = cgmodel.monomer_types[0]
+    # sigma_bb = 2.25 A
+    # epsilon_bb = 1.5 kJ/mol
+    # sigma_sc = 3.5 A
+    # epsilon_sc = 5.0 kJ/mol
+    
+    B = copy.deepcopy(A)
+    # A and B need separate names:
+    B["monomer_name"] = "B"
+
+    monomer_list = [A,B]
+    
+    nmono = len(cgmodel.sequence)
+    
+    sequence = []
+    for i in range(int(nmono/2)):
+        sequence.append(0)
+        sequence.append(1)
+
+    frame_begin = 100
+    frame_end = 150
+    sample_spacing = 6
+    sparsify_stride = 3
+    num_intermediate_states = 1
+
+    # Re-evaluate OpenMM energies:
+    (seq_FWHM, seq_FWHM_uncertainty,
+    seq_Cv, seq_Cv_uncertainty, seq_N_eff) = eval_energy_sequences(
+        cgmodel,
+        dcd_file_list,
+        temperature_list,
+        monomer_list=monomer_list,
+        sequence=sequence,
+        num_intermediate_states=num_intermediate_states,
+        n_trial_boot=10,
+        plot_dir=output_directory,
+        output_data=output_data,
+        frame_begin=frame_begin,
+        frame_end=frame_end,
+        sample_spacing=sample_spacing,
+        sparsify_stride=sparsify_stride,
+        verbose=True,
+        n_cpu=1,
+    )
+
+        
+def test_eval_FWHM_sequences_AB(tmpdir):
+    """
+    Test sequence energy/heat capacity evaluation code with a new monomer type B defined,
+    checking that heat capacity curve matches the original reference simulation.
+    Sequence is single list of monomer dicts.
+    Single heat capacity calculation (no bootstrapping)
+    """
+    output_directory = tmpdir.mkdir("output")    
+    
+    # Replica exchange settings
+    number_replicas = 12
+    min_temp = 200.0 * unit.kelvin
+    max_temp = 600.0 * unit.kelvin
+    temperature_list = get_temperature_list(min_temp, max_temp, number_replicas)
+    
+    # Load in cgmodel
+    cgmodel = pickle.load(open(f"{data_path}/stored_cgmodel.pkl", "rb" ))
+    
+    # Data file with simulated energies:
+    output_data = os.path.join(data_path, "output.nc")
+    
+    # Create list of replica trajectories to analyze
+    dcd_file_list = []
+    for i in range(len(temperature_list)):
+        dcd_file_list.append(f"{data_path}/replica_{i+1}.dcd")
+    
+    # Set up monomer dictionaries:
+    A = cgmodel.monomer_types[0]
+    # sigma_bb = 2.25 A
+    # epsilon_bb = 1.5 kJ/mol
+    # sigma_sc = 3.5 A
+    # epsilon_sc = 5.0 kJ/mol
+
+    mass = 100 * unit.amu
+        
+    bb2 = {
+        "particle_type_name": "bb2",
+        "sigma": 2.20 * unit.angstrom,
+        "epsilon": 1.25 * unit.kilojoules_per_mole,
+        "mass": mass
+    }
+    sc2 = {
+        "particle_type_name": "sc2",
+        "sigma": 3.55 * unit.angstrom,
+        "epsilon": 5.25 * unit.kilojoules_per_mole,
+        "mass": mass
+    }
+
+    B = {
+        "monomer_name": "B",
+        "particle_sequence": [bb2, sc2],
+        "bond_list": [[0, 1]],
+        "start": 0,
+        "end": 0,
+    }
+
+    monomer_list = [A,B]
+    
+    nmono = len(cgmodel.sequence)
+    
+    sequence = []
+    for i in range(int(nmono/2)):
+        sequence.append(A)
+        sequence.append(B)
+        
+    frame_begin = 100
+    frame_end = 150
+    sample_spacing = 1
+    sparsify_stride = 1
+    num_intermediate_states = 1
+
+    # Re-evaluate OpenMM energies:
+    (seq_FWHM, seq_FWHM_uncertainty,
+    seq_Cv, seq_Cv_uncertainty, seq_N_eff) = eval_energy_sequences(
+        cgmodel,
+        dcd_file_list,
+        temperature_list,
+        monomer_list=monomer_list,
+        sequence=sequence,
+        num_intermediate_states=num_intermediate_states,
+        n_trial_boot=None,
+        plot_dir=output_directory,
+        output_data=output_data,
+        frame_begin=frame_begin,
+        frame_end=frame_end,
+        sample_spacing=sample_spacing,
+        sparsify_stride=sparsify_stride,
+        verbose=True,
+        n_cpu=1,
+    )
+
+  
+def test_eval_FWHM_sequences_ABC(tmpdir):
+    """
+    Test sequence energy/heat capacity evaluation code with new monomer types B,C defined,
+    checking that heat capacity curve matches the original reference simulation.
+    Sequence is single list of monomer dicts.
+    Single heat capacity calculation (no bootstrapping)
+    """
+    output_directory = tmpdir.mkdir("output")    
+    
+    # Replica exchange settings
+    number_replicas = 12
+    min_temp = 200.0 * unit.kelvin
+    max_temp = 600.0 * unit.kelvin
+    temperature_list = get_temperature_list(min_temp, max_temp, number_replicas)
+    
+    # Load in cgmodel
+    cgmodel = pickle.load(open(f"{data_path}/stored_cgmodel.pkl", "rb" ))
+    
+    # Data file with simulated energies:
+    output_data = os.path.join(data_path, "output.nc")
+    
+    # Create list of replica trajectories to analyze
+    dcd_file_list = []
+    for i in range(len(temperature_list)):
+        dcd_file_list.append(f"{data_path}/replica_{i+1}.dcd")
+    
+    # Set up monomer dictionaries:
+    A = cgmodel.monomer_types[0]
+    # sigma_bb = 2.25 A
+    # epsilon_bb = 1.5 kJ/mol
+    # sigma_sc = 3.5 A
+    # epsilon_sc = 5.0 kJ/mol
+
+    mass = 100 * unit.amu
+        
+    bb2 = {
+        "particle_type_name": "bb2",
+        "sigma": 2.20 * unit.angstrom,
+        "epsilon": 1.25 * unit.kilojoules_per_mole,
+        "mass": mass
+    }
+    sc2 = {
+        "particle_type_name": "sc2",
+        "sigma": 3.55 * unit.angstrom,
+        "epsilon": 5.25 * unit.kilojoules_per_mole,
+        "mass": mass
+    }
+    sc3 = {
+        "particle_type_name": "sc2",
+        "sigma": 3.55 * unit.angstrom,
+        "epsilon": 4.25 * unit.kilojoules_per_mole,
+        "mass": mass
+    }    
+
+    B = {
+        "monomer_name": "B",
+        "particle_sequence": [bb2, sc2],
+        "bond_list": [[0, 1]],
+        "start": 0,
+        "end": 0,
+    }
+    
+    C = {
+        "monomer_name": "B",
+        "particle_sequence": [bb2, sc3],
+        "bond_list": [[0, 1]],
+        "start": 0,
+        "end": 0,
+    }    
+
+    monomer_list = [A,B,C]
+    
+    nmono = len(cgmodel.sequence)
+    
+    sequence = []
+    for i in range(int(nmono/3)):
+        sequence.append(A)
+        sequence.append(B)
+        sequence.append(C)
+        
+    frame_begin = 100
+    frame_end = 150
+    sample_spacing = 1
+    sparsify_stride = 1
+    num_intermediate_states = 1
+
+    # Re-evaluate OpenMM energies:
+    (seq_FWHM, seq_FWHM_uncertainty,
+    seq_Cv, seq_Cv_uncertainty, seq_N_eff) = eval_energy_sequences(
+        cgmodel,
+        dcd_file_list,
+        temperature_list,
+        monomer_list=monomer_list,
+        sequence=sequence,
+        num_intermediate_states=num_intermediate_states,
+        n_trial_boot=None,
+        plot_dir=output_directory,
+        output_data=output_data,
+        frame_begin=frame_begin,
+        frame_end=frame_end,
+        sample_spacing=sample_spacing,
+        sparsify_stride=sparsify_stride,
+        verbose=True,
+        n_cpu=1,
+    )
+    
+  

--- a/cg_openmm/tests/test_native_contacts.py
+++ b/cg_openmm/tests/test_native_contacts.py
@@ -45,10 +45,10 @@ def test_native_contacts_pdb(tmpdir):
         
     # Set cutoff parameters:
     # Cutoff for native structure pairwise distances:
-    native_contact_cutoff = 3.5* unit.angstrom
+    native_contact_cutoff = 4.0* unit.angstrom
 
     # Tolerance for current trajectory distances:
-    native_contact_tol = 1.2
+    native_contact_tol = 1.5
     
     # Determine native contacts:
     native_contact_list, native_contact_distances, contact_type_dict = get_native_contacts(
@@ -102,10 +102,10 @@ def test_native_contacts_dcd(tmpdir):
     
     # Set cutoff parameters:
     # Cutoff for native structure pairwise distances:
-    native_contact_cutoff = 3.5* unit.angstrom
+    native_contact_cutoff = 4.0* unit.angstrom
 
     # Tolerance for current trajectory distances:
-    native_contact_tol = 1.2
+    native_contact_tol = 1.5
     
     # Determine native contacts:
     native_contact_list, native_contact_distances, contact_type_dict = get_native_contacts(
@@ -190,10 +190,10 @@ def test_expectations_fraction_contacts_pdb(tmpdir):
 
     # Set cutoff parameters:
     # Cutoff for native structure pairwise distances:
-    native_contact_cutoff = 5.0* unit.angstrom
+    native_contact_cutoff = 4.0* unit.angstrom
 
     # Tolerance for current trajectory distances:
-    native_contact_tol = 1.3
+    native_contact_tol = 1.5
 
     # Get native contacts:
     native_contact_list, native_contact_distances, contact_type_dict = get_native_contacts(
@@ -247,7 +247,7 @@ def test_expectations_fraction_contacts_pdb(tmpdir):
     # Test free energy of folding:
     
     # Cutoff for native contact fraction folded vs. unfolded states:
-    Q_folded = 0.50
+    Q_folded = 0.40
 
     full_T_list, deltaF_values, deltaF_uncertainty = expectations_free_energy(
         Q,
@@ -346,10 +346,10 @@ def test_expectations_fraction_contacts_dcd(tmpdir):
 
     # Set cutoff parameters:
     # Cutoff for native structure pairwise distances:
-    native_contact_cutoff = 5.0* unit.angstrom
+    native_contact_cutoff = 4.0* unit.angstrom
 
     # Tolerance for current trajectory distances:
-    native_contact_tol = 1.3
+    native_contact_tol = 1.5
 
     # Get native contacts:
     native_contact_list, native_contact_distances, contact_type_dict = get_native_contacts(

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -8,7 +8,7 @@ dependencies:
   - mdtraj
   - mpi4py
   - numpy
-  - openmm
+  - openmm <= 7.5
   - openmmtools
   - pickleshare
   - pip

--- a/examples/evaluating_FWHM_sequences/scan_sequences_FWHM.py
+++ b/examples/evaluating_FWHM_sequences/scan_sequences_FWHM.py
@@ -1,0 +1,130 @@
+#!~/anaconda3/bin/python
+
+import os
+import pickle
+
+from cg_openmm.parameters.evaluate_energy import *
+from cg_openmm.parameters.reweight import get_temperature_list
+from cg_openmm.thermo.calc import *
+from simtk import unit
+
+# This example demonstrates how to use the energy evaluation and MBAR reweighting
+# framework to calculate the full-width half-maximum of a non-simulated monomer sequence,
+# given a reference cgmodel and corresponding replica trajectories and energies.
+
+# Set location of reference simulation output files:
+output_directory = '../run_replica_exchange/output/'
+output_data = os.path.join(output_directory, "output.nc")
+
+# Load in reference trajectory stats:
+analysis_stats = pickle.load(open("../run_replica_exchange/analysis_stats_discard_20ns.pkl","rb"))
+
+# Load in reference CGModel
+cgmodel = pickle.load(open("../run_replica_exchange/stored_cgmodel.pkl","rb"))
+
+# Get temperature list (logarithmic spacing) corresponding to trajectory file list:
+n_replicas = 12
+min_temp = 200.0 * unit.kelvin
+max_temp = 600.0 * unit.kelvin
+temperature_list = get_temperature_list(min_temp, max_temp, n_replicas)
+
+# Create list of reference trajectory files to use for evaluating energies
+rep_traj_file_list = []
+
+for i in range(n_replicas):
+    rep_traj_file_list.append(f'{output_directory}/replica_{i+1}.dcd')
+    
+# Specify A and B monomer types:
+# ***Note: these must have the same topology as the monomer(s) defined in the reference cgmodel
+
+mass = 100 * unit.amu
+
+# Particle definitions:
+bb1 = {
+    "particle_type_name": "bb1",
+    "sigma": 2.25 * unit.angstrom,
+    "epsilon": 1.5 * unit.kilojoules_per_mole,
+    "mass": mass
+}
+bb2 = {
+    "particle_type_name": "bb2",
+    "sigma": 2.25 * unit.angstrom,
+    "epsilon": 1.5 * unit.kilojoules_per_mole,
+    "mass": mass
+}
+sc1 = {
+    "particle_type_name": "sc1",
+    "sigma": 3.5 * unit.angstrom,
+    "epsilon": 5.0 * unit.kilojoules_per_mole,
+    "mass": mass
+}
+sc2 = {
+    "particle_type_name": "sc2",
+    "sigma": 3.5 * unit.angstrom,
+    "epsilon": 6.0 * unit.kilojoules_per_mole,
+    "mass": mass
+}
+
+
+# Monomer definitions:
+A = {
+    "monomer_name": "A",
+    "particle_sequence": [bb1, sc1],
+    "bond_list": [[0, 1]],
+    "start": 0,
+    "end": 0,
+}
+
+B = {
+    "monomer_name": "B",
+    "particle_sequence": [bb2, sc2],
+    "bond_list": [[0, 1]],
+    "start": 0,
+    "end": 0,
+}
+
+# Set monomer list and sequences:
+
+monomer_list = [A,B]
+seq_list = []
+
+# AB alternating copolymer:
+seq_1 = []
+for i in range(int(len(cgmodel.sequence)/2)):
+    seq_1.append(A)
+    seq_1.append(B)
+    
+# AB multiblock copolymer:
+seq_2 = []
+for i in range(int(len(cgmodel.sequence)/8)):
+    seq_2.append(A)
+    seq_2.append(A)
+    seq_2.append(A)
+    seq_2.append(A)
+    
+    seq_2.append(B)
+    seq_2.append(B)
+    seq_2.append(B)
+    seq_2.append(B)
+    
+seq_list.append(seq_1)
+seq_list.append(seq_2)    
+
+# Set frames to analyze:
+frame_begin = analysis_stats["production_start"]
+sample_spacing = analysis_stats["energy_decorrelation"]
+sparsify_stride = 2 # Evaluate energies of every other frame
+frame_end = -1
+
+# Set heat capacity calculation parameters:
+n_trial_boot = 200          # Number of bootstraping trials
+num_intermediate_states = 3 # Number of intemediate temperature states for MBAR calculation
+
+(seq_FWHM, seq_FWHM_uncertainty,
+seq_Cv, seq_Cv_uncertainty, seq_N_eff) = eval_energy_sequences(
+    cgmodel, rep_traj_file_list, temperature_list, monomer_list,
+    output_data=output_data, sequence=seq_list, 
+    frame_begin=frame_begin, frame_end=frame_end, sparsify_stride=sparsify_stride,
+    sample_spacing=sample_spacing, num_intermediate_states=num_intermediate_states,
+    n_trial_boot=n_trial_boot,
+    verbose=True, n_cpu=12)


### PR DESCRIPTION
## Description
This PR adds the framework for varying sequences to the heat capacity reweighting code (#126). For now it is pretty specific to binary sequences in which each monomer type has a backbone and sidechain bead type.

**Input format for sequence scans:**
- List of monomer dictionaries (as in cgmodel construction), which list the particle sequences within. We can set the epsilon and sigma LJ parameter for each particle (4 types in total) in those monomer dictionaries.
- Sequences are specified in a list of lists (or just a single list). There is also an option to scan all possible sequences, which doesn't really work for the 24mer models I've been using (runs out of memory making a list with > 1 million sequences.
- cgmodel with initial topology, replica trajectory files and energy .nc files for the reference simulation

**Energy evaluation**
- First, we compute the distances between nonbonded pairs for all specified frames in the replica trajectories (MDTraj). This takes about 1 minute for 1.2 million frames for a 24mer 1-1 model. Also precompute the r^12 and r^6 terms here.
- Compute the bonded energies using the original cgmodel and trajectories (done using the existing energy evaluation function, with changing the epsilons to 0). This takes about 10-15min for 1.2 million frames on 12 cpu (multiprocessor parallization).
- Determine the particle types of all pairs in the new nonbonded list, and construct the vectors `4*eps_ij*sigma_ij^12` and `4*eps_ij*sigma_ij^6` for the nonbonded list.
- Apply the LJ vectors to the precomputed r^12 and r^6 matrices, and sum to get the nonbonded energy.
- Reduce the nonbonded energies, evaluating at all states, and add the the bonded energy.
- For each new sequence, we can get the potential energies in ~5-10 seconds. 

With the reduced potential energies, we can run the heat capacity function (bootstrapping or single evaluation). This is going to be the limiting step for scanning large sequences (~1-2 minutes). It's probably worth revisiting the efficiency of the Cv code, especially with regards to re-using the same MBAR object.

This is mostly working. If I run the code for the same sequence as the original, the heat capacity curves are mostly matching, but the uncertainties in the re-evaluated Cv curve seem much too high.

Original heat capacity for full simulation:
![image](https://user-images.githubusercontent.com/64790444/131542388-7e54640c-69d8-46c0-bbc5-e1e3556f50a4.png)

Re-evaluated heat capacity curve:
![image](https://user-images.githubusercontent.com/64790444/131542504-1f8c7f1d-18c7-4d4e-8a26-fcfec164ee94.png)

## Todos
  - [x] Add tests - reproduce the simulated Cv curve when no changes are made to the sequence
  - [x] Make the input parsing more general. Right now we must specify a particle sequence of [bb_type, sc_type] for each monomer to match the topology in the original cgmodel.
  - [x] Add examples

## Status
- [x] Ready to go