### PR TITLE
Sequence optimization update, fix native distances bug

### DIFF
--- a/cg_openmm/parameters/evaluate_energy.py
+++ b/cg_openmm/parameters/evaluate_energy.py
@@ -956,10 +956,18 @@ def eval_energy_sequences(cgmodel, file_list, temperature_list, monomer_list, se
     beta_all_kJ_mol = 1/(kB.in_units_of(unit.kilojoule_per_mole/unit.kelvin)*temperature_list)    
     
     # Set up results dicts:
-    seq_FWHM = {}
-    seq_FWHM_uncertainty = {}
     seq_Cv = {}
     seq_Cv_uncertainty = {}
+
+    seq_Tm = {}
+    seq_Tm_uncertainty = {}
+    
+    seq_Cv_height = {}
+    seq_Cv_height_uncertainty = {}
+    
+    seq_FWHM = {}
+    seq_FWHM_uncertainty = {}    
+    
     seq_N_eff = {}
     
     for seq in seq_unique:
@@ -1076,15 +1084,23 @@ def eval_energy_sequences(cgmodel, file_list, temperature_list, monomer_list, se
         
         seq_time_cv_done = time.perf_counter()
         if verbose:
-            print(f'Cv eval done ({seq_time_cv_done-seq_time_energies_done:.4f} s)')
+            print(f'Cv eval done ({seq_time_cv_done-seq_time_energies_done:.4f} s)\n')
+        
+        seq_Cv[seq_print] = C_v_values
+        seq_Cv_uncertainty[seq_print] = C_v_uncertainty
+        
+        seq_Tm[seq_print] = Tm_value
+        seq_Tm_uncertainty[seq_print] = Tm_uncertainty
+        
+        seq_Cv_height[seq_print] = Cv_height_value
+        seq_Cv_height_uncertainty[seq_print] = Cv_height_uncertainty        
         
         seq_FWHM[seq_print] = FWHM_value
         seq_FWHM_uncertainty[seq_print] = FWHM_uncertainty
-        seq_Cv[seq_print] = C_v_values
-        seq_Cv_uncertainty[seq_print] = C_v_uncertainty
+        
         seq_N_eff[seq_print] = N_eff_values
     
-    return seq_FWHM, seq_FWHM_uncertainty, seq_Cv, seq_Cv_uncertainty, seq_N_eff
+    return seq_Cv, seq_Cv_uncertainty, seq_Tm, seq_Tm_uncertainty, seq_Cv_height, seq_Cv_height_uncertainty, seq_FWHM, seq_FWHM_uncertainty, seq_N_eff
 
 
 def get_replica_reeval_energies(replica, temperature_list, file_list, topology, system,

--- a/cg_openmm/parameters/secondary_structure.py
+++ b/cg_openmm/parameters/secondary_structure.py
@@ -69,12 +69,13 @@ def get_native_contacts(cgmodel, native_structure_file, native_contact_distance_
     for interaction in range(len(nonbonded_inclusion_list)):
         if native_structure_distances[interaction] < (native_contact_distance_cutoff):
             native_contact_list.append(nonbonded_inclusion_list[interaction])
-            native_contact_distances_list.append(distances(native_contact_list, native_structure))
+    
+    native_contact_distances_list = distances(native_contact_list, native_structure)
     
     # Units get messed up if converted using np.asarray
     native_contact_distances = np.zeros((len(native_contact_distances_list)))
     for i in range(len(native_contact_distances_list)):
-        native_contact_distances[i] = native_contact_distances_list[i][0].value_in_unit(unit.nanometer)
+        native_contact_distances[i] = native_contact_distances_list[i].value_in_unit(unit.nanometer)
     native_contact_distances *= unit.nanometer
     
     # Determine particle types of the native contacts:

--- a/cg_openmm/tests/test_energy_eval.py
+++ b/cg_openmm/tests/test_energy_eval.py
@@ -1432,8 +1432,11 @@ def test_eval_FWHM_sequences_no_change_1(tmpdir):
     num_intermediate_states = 1
 
     # Re-evaluate OpenMM energies:
-    (seq_FWHM, seq_FWHM_uncertainty,
-    seq_Cv, seq_Cv_uncertainty, seq_N_eff) = eval_energy_sequences(
+    (seq_Cv, seq_Cv_uncertainty,
+    seq_Tm, seq_Tm_uncertainty,
+    seq_Cv_height, seq_Cv_height_uncertainty,
+    seq_FWHM, seq_FWHM_uncertainty,
+    seq_N_eff) = eval_energy_sequences(
         cgmodel,
         dcd_file_list,
         temperature_list,
@@ -1524,8 +1527,11 @@ def test_eval_FWHM_sequences_no_change_2(tmpdir):
     num_intermediate_states = 1
 
     # Re-evaluate OpenMM energies:
-    (seq_FWHM, seq_FWHM_uncertainty,
-    seq_Cv, seq_Cv_uncertainty, seq_N_eff) = eval_energy_sequences(
+    (seq_Cv, seq_Cv_uncertainty,
+    seq_Tm, seq_Tm_uncertainty,
+    seq_Cv_height, seq_Cv_height_uncertainty,
+    seq_FWHM, seq_FWHM_uncertainty,
+    seq_N_eff) = eval_energy_sequences(
         cgmodel,
         dcd_file_list,
         temperature_list,
@@ -1609,8 +1615,11 @@ def test_eval_FWHM_boot_sequences_no_change_1(tmpdir):
     num_intermediate_states = 1
 
     # Re-evaluate OpenMM energies:
-    (seq_FWHM, seq_FWHM_uncertainty,
-    seq_Cv, seq_Cv_uncertainty, seq_N_eff) = eval_energy_sequences(
+    (seq_Cv, seq_Cv_uncertainty,
+    seq_Tm, seq_Tm_uncertainty,
+    seq_Cv_height, seq_Cv_height_uncertainty,
+    seq_FWHM, seq_FWHM_uncertainty,
+    seq_N_eff) = eval_energy_sequences(
         cgmodel,
         dcd_file_list,
         temperature_list,
@@ -1682,8 +1691,11 @@ def test_eval_FWHM_boot_sequences_no_change_2(tmpdir):
     num_intermediate_states = 1
 
     # Re-evaluate OpenMM energies:
-    (seq_FWHM, seq_FWHM_uncertainty,
-    seq_Cv, seq_Cv_uncertainty, seq_N_eff) = eval_energy_sequences(
+    (seq_Cv, seq_Cv_uncertainty,
+    seq_Tm, seq_Tm_uncertainty,
+    seq_Cv_height, seq_Cv_height_uncertainty,
+    seq_FWHM, seq_FWHM_uncertainty,
+    seq_N_eff) = eval_energy_sequences(
         cgmodel,
         dcd_file_list,
         temperature_list,
@@ -1773,8 +1785,11 @@ def test_eval_FWHM_sequences_AB(tmpdir):
     num_intermediate_states = 1
 
     # Re-evaluate OpenMM energies:
-    (seq_FWHM, seq_FWHM_uncertainty,
-    seq_Cv, seq_Cv_uncertainty, seq_N_eff) = eval_energy_sequences(
+    (seq_Cv, seq_Cv_uncertainty,
+    seq_Tm, seq_Tm_uncertainty,
+    seq_Cv_height, seq_Cv_height_uncertainty,
+    seq_FWHM, seq_FWHM_uncertainty,
+    seq_N_eff) = eval_energy_sequences(
         cgmodel,
         dcd_file_list,
         temperature_list,
@@ -1880,8 +1895,11 @@ def test_eval_FWHM_sequences_ABC(tmpdir):
     num_intermediate_states = 1
 
     # Re-evaluate OpenMM energies:
-    (seq_FWHM, seq_FWHM_uncertainty,
-    seq_Cv, seq_Cv_uncertainty, seq_N_eff) = eval_energy_sequences(
+    (seq_Cv, seq_Cv_uncertainty,
+    seq_Tm, seq_Tm_uncertainty,
+    seq_Cv_height, seq_Cv_height_uncertainty,
+    seq_FWHM, seq_FWHM_uncertainty,
+    seq_N_eff) = eval_energy_sequences(
         cgmodel,
         dcd_file_list,
         temperature_list,
@@ -1984,8 +2002,11 @@ def test_eval_FWHM_sequences_multi_1(tmpdir):
     num_intermediate_states = 1
 
     # Re-evaluate OpenMM energies:
-    (seq_FWHM, seq_FWHM_uncertainty,
-    seq_Cv, seq_Cv_uncertainty, seq_N_eff) = eval_energy_sequences(
+    (seq_Cv, seq_Cv_uncertainty,
+    seq_Tm, seq_Tm_uncertainty,
+    seq_Cv_height, seq_Cv_height_uncertainty,
+    seq_FWHM, seq_FWHM_uncertainty,
+    seq_N_eff) = eval_energy_sequences(
         cgmodel,
         dcd_file_list,
         temperature_list,
@@ -2088,8 +2109,11 @@ def test_eval_FWHM_sequences_multi_2(tmpdir):
     num_intermediate_states = 1
 
     # Re-evaluate OpenMM energies:
-    (seq_FWHM, seq_FWHM_uncertainty,
-    seq_Cv, seq_Cv_uncertainty, seq_N_eff) = eval_energy_sequences(
+    (seq_Cv, seq_Cv_uncertainty,
+    seq_Tm, seq_Tm_uncertainty,
+    seq_Cv_height, seq_Cv_height_uncertainty,
+    seq_FWHM, seq_FWHM_uncertainty,
+    seq_N_eff) = eval_energy_sequences(
         cgmodel,
         dcd_file_list,
         temperature_list,

--- a/examples/evaluating_FWHM_sequences/scan_sequences_FWHM.py
+++ b/examples/evaluating_FWHM_sequences/scan_sequences_FWHM.py
@@ -120,8 +120,11 @@ frame_end = -1
 n_trial_boot = 200          # Number of bootstraping trials
 num_intermediate_states = 3 # Number of intemediate temperature states for MBAR calculation
 
-(seq_FWHM, seq_FWHM_uncertainty,
-seq_Cv, seq_Cv_uncertainty, seq_N_eff) = eval_energy_sequences(
+(seq_Cv, seq_Cv_uncertainty,
+seq_Tm, seq_Tm_uncertainty,
+seq_Cv_height, seq_Cv_height_uncertainty,
+seq_FWHM, seq_FWHM_uncertainty,
+seq_N_eff) = eval_energy_sequences(
     cgmodel, rep_traj_file_list, temperature_list, monomer_list,
     output_data=output_data, sequence=seq_list, 
     frame_begin=frame_begin, frame_end=frame_end, sparsify_stride=sparsify_stride,


### PR DESCRIPTION
## Description
1. This PR updates the sequence eval code to also output the melting point and relative Cv peak height (with uncertainties) in addition to the FWHM, Cv curve, and number of effective samples from MBAR. These are each stored in dictionaries, with the monomer sequence as the key. The order of output is the same as that which the heat capacity bootstrapping function returns.

2. On a separate note, this fixes an error I found with the native distance array output in get_native_contacts(), which is used in the generalized native contact 1d and 2d optimizations (helix contacts are separate and didn't have this issue).

## Status
- [ ] Ready to go