### PR TITLE
Energy decomposition function, native contacts by configurational state 

### DIFF
--- a/cg_openmm/parameters/evaluate_energy.py
+++ b/cg_openmm/parameters/evaluate_energy.py
@@ -1156,3 +1156,64 @@ def get_replica_reeval_energies(replica, temperature_list, file_list, topology, 
             U_eval_rep[j,k] = (potential_energy*beta_all[j])
     
     return U_eval_rep, replica 
+    
+    
+def energy_decomposition(cgmodel, positions_file):  
+    """
+    Given a cgmodel with a topology and system and coordinates in positions_file,
+    perform an OpenMM energy decomposition.
+
+    :param cgmodel: CGModel() class object to evaluate energy with
+    :type cgmodel: class
+
+    :param positions_file: Path to pdb or dcd file containing molecular coordinates
+    :type positions_file: str
+    
+    :returns:
+        - U_decomposition - dict mapping force names to contribution to total energy.
+    """
+    
+    topology = cgmodel.topology
+    system = cgmodel.system
+    
+    # Load in the coordinates as mdtraj object:
+    if positions_file[-3:] == 'dcd':
+        traj = md.load(positions_file,top=md.Topology.from_openmm(topology))
+    else:
+        traj = md.load(positions_file)
+    
+    positions = traj[0].xyz[0]*unit.nanometer
+    
+    # Set up simulation object:
+    simulation_time_step = 5.0 * unit.femtosecond
+    friction = 0.0 / unit.picosecond
+    integrator = LangevinIntegrator(
+        0.0 * unit.kelvin, friction, simulation_time_step.in_units_of(unit.picosecond)
+    )
+    simulation = Simulation(topology, cgmodel.system, integrator)
+    simulation.context.setPositions(positions)    
+    
+    # Set force groups:
+    force_names = {}
+    U_decomposition = {}
+    
+    for force_index, force in enumerate(simulation.system.getForces()):
+        # These are the overall classes of forces, not the particle-specific forces
+        force_names[force_index] = force.__class__.__name__
+        force.setForceGroup(force_index)    
+   
+    # Need to create a new simulation object with the updated force groups:
+    integrator_new = LangevinIntegrator(
+        0.0 * unit.kelvin, friction, simulation_time_step.in_units_of(unit.picosecond)
+    )
+    simulation_new = Simulation(topology, simulation.system, integrator_new) 
+    simulation_new.context.setPositions(positions)
+     
+    total_energy = simulation_new.context.getState(getEnergy=True).getPotentialEnergy()      
+    U_decomposition['total'] = total_energy
+     
+    for force_index, force in enumerate(simulation_new.system.getForces()):    
+        force_names[force_index] = force.__class__.__name__
+        U_decomposition[force_names[force_index]] = simulation_new.context.getState(getEnergy=True,groups={force_index}).getPotentialEnergy()        
+
+    return U_decomposition

--- a/cg_openmm/parameters/secondary_structure.py
+++ b/cg_openmm/parameters/secondary_structure.py
@@ -364,6 +364,207 @@ def expectations_fraction_contacts(fraction_native_contacts, frame_begin=0, samp
     return_results["dQ"] = dQ_expect
 
     return return_results
+    
+    
+def expectations_partial_contact_fractions(array_folded_states, fraction_native_contacts,
+    frame_begin=0, sample_spacing=1, output_data="output/output.nc", num_intermediate_states=0,
+    bootstrap_energies=None, transition_list=None):
+    """
+    For systems with more than 2 conformational states, compute the expectation fraction of contacts
+    vs temperature for each individual transition by summing the appropriate mbar weights.
+    
+    :param array_folded_states: a precomputed array classifying the different conformational states
+    :type array_folded_states: 2d numpy array (int)     
+    
+    :param fraction_native_contacts: The fraction of native contacts for all selected frames in the trajectories.
+    :type fraction_native_contacts: numpy array (float * nframes x nreplicas)
+    
+    :param frame_begin: index of first frame defining the range of samples to use as a production period (default=0)
+    :type frame_begin: int
+
+    :param sample_spacing: spacing of uncorrelated data points, for example determined from pymbar timeseries subsampleCorrelatedData (default=1)
+    :type sample_spacing: int       
+    
+    :param output_data: Path to the output data for a NetCDF-formatted file containing replica exchange simulation data (default="output/output.nc")                                                                                                  
+    :type output_data: str
+    
+    :param num_intermediate_states: The number of states to insert between existing simulated temperature states (default=0)
+    :type num_intermediate_states: int    
+    
+    :param bootstrap_energies: a custom replica_energies array to be used for bootstrapping calculations. Used instead of the energies in the .nc file. (default=None)
+    :type bootstrap_energies: 2d numpy array (float)
+    
+    :param transition_list: a list containing the allowed transitions to a folded state, such as '0_1' or '1_2'. 
+    :type transition_list: list ( str )
+    
+    :returns:
+       - Q_expect_confs ( dict ) - dictionary of the form {'m_n': 1D numpy array} containing partial contact fractions for each transition between states m and n
+       - T_list_out ( np.array ( float * unit.simtk.temperature ) ) Temperature list corresponding to the partial contact fraction values
+    """
+
+    if bootstrap_energies is not None:
+        # Use a subsampled replica_energy matrix instead of reading from file
+        replica_energies = bootstrap_energies    
+        # Still need to get the thermodynamic states
+        reporter = MultiStateReporter(output_data, open_mode="r")
+    else:
+        # extract reduced energies and the state indices from the .nc  
+        reporter = MultiStateReporter(output_data, open_mode="r")
+        analyzer = ReplicaExchangeAnalyzer(reporter)
+        (
+            replica_energies_all,
+            unsampled_state_energies,
+            neighborhoods,
+            replica_state_indices,
+        ) = analyzer.read_energies()
+        
+        # Select production frames to analyze
+        replica_energies = replica_energies_all[:,:,frame_begin::sample_spacing]
+        
+        # Also apply frame selection to array_folded_states (starts at frame_begin):
+        array_folded_states = array_folded_states[::sample_spacing,:]        
+        
+        # Check the size of the fraction_native_contacts array:
+        if np.shape(replica_energies)[2] != np.shape(fraction_native_contacts)[0]:
+            # Mismatch in number of frames.
+            if np.shape(replica_energies_all[:,:,frame_begin::sample_spacing])[2] == np.shape(fraction_native_contacts[::sample_spacing,:])[0]:
+                # Correct starting frame, need to apply sampling stride:
+                fraction_native_contacts = fraction_native_contacts[::sample_spacing,:]
+            elif np.shape(replica_energies_all)[2] == np.shape(fraction_native_contacts)[0]:
+                # This is the full fraction_native_contacts, slice production frames:
+                fraction_native_contacts = fraction_native_contacts[production_start::sample_spacing,:]
+    
+    # Get the temperature list from .nc file:
+    states = reporter.read_thermodynamic_states()[0]
+    
+    temperature_list = []
+    for s in states:
+        temperature_list.append(s.temperature)
+
+    # Close the data file:
+    reporter.close()
+
+    # determine the numerical values of beta at each state in units consistent with the temperature
+    Tunit = temperature_list[0].unit
+    temps = np.array([temp.value_in_unit(Tunit)  for temp in temperature_list])  # should this just be array to begin with
+    beta_k = 1 / (kB.value_in_unit(unit.kilojoule_per_mole/Tunit) * temps)
+
+    # convert the energies from replica/evaluated state/sample form to evaluated state/sample form
+    replica_energies = pymbar.utils.kln_to_kn(replica_energies)
+    n_samples = len(replica_energies[0,:])
+    # n_samples in [nreplica x nsamples_per_replica]
+    
+    # calculate the number of states we need expectations at.  We want it at all of the original
+    # temperatures, each intermediate temperature, and then temperatures +/- from the original
+    # to take finite derivatives.
+
+    # create  an array for the temperature and energy for each state, including the
+    # finite different state.
+    n_sampled_T = len(temps)
+    n_unsampled_states = (n_sampled_T + (n_sampled_T-1)*num_intermediate_states)
+    unsampled_state_energies = np.zeros([n_unsampled_states,n_samples])
+    full_T_list = np.zeros(n_unsampled_states)
+
+    # delta is the spacing between temperatures.
+    delta = np.zeros(n_sampled_T-1)
+
+    # fill in a list of temperatures at all original temperatures and all intermediate states.
+    full_T_list[0] = temps[0]  
+    t = 0
+    for i in range(n_sampled_T-1):
+        delta[i] = (temps[i+1] - temps[i])/(num_intermediate_states+1)
+        for j in range(num_intermediate_states+1):
+            full_T_list[t] = temps[i] + delta[i]*j
+            t += 1
+    full_T_list[t] = temps[-1]
+    n_T_vals = t+1
+
+    # calculate betas of all of these temperatures
+    beta_full_k = 1 / (kB.value_in_unit(unit.kilojoule_per_mole/Tunit) * full_T_list)
+    
+    ti = 0
+    N_k = np.zeros(n_unsampled_states)
+    for k in range(n_unsampled_states):
+        # Calculate the reduced energies at all temperatures, sampled and unsample.
+        unsampled_state_energies[k, :] = replica_energies[0,:]*(beta_full_k[k]/beta_k[0])
+        if ti < len(temps):
+            # store in N_k which states do and don't have samples.
+            if full_T_list[k] == temps[ti]:
+                ti += 1
+                N_k[k] = n_samples//len(temps)  # these are the states that have samples
+
+    # call MBAR to find weights at all states, sampled and unsampled
+    mbarT = pymbar.MBAR(unsampled_state_energies,N_k,verbose=False, relative_tolerance=1e-12);
+    
+    # Get the weights from the mbar object:
+    # These weights include all of the intermediate temperatures 
+    w_nk = mbarT.W_nk    
+    
+    # Now we have the weights at all temperatures, so we can
+    # calculate the expectations.
+    
+    # Reshape fraction native contacts [nframes x nreplicas] column by column for pymbar
+    Q = np.reshape(fraction_native_contacts,np.size(fraction_native_contacts), order='F')
+    
+    # Repeat for corresponding array_folded_state
+    array_folded_states = np.reshape(array_folded_states,(np.size(array_folded_states)),order='F')       
+            
+    # Here we need to classify each of the sample mbar weights
+    num_confs = {} # w_i*U_i, for each state.
+    den_confs = {} # w_i
+    Q_expect_confs = {} # Contact fraction expectations
+    
+    n_conf_states = len(np.unique(array_folded_states))
+    
+    if n_conf_states == 1:
+        print(f'Only 1 configurational state found. Exiting...')
+        exit()
+    
+    print(f'n_conf_states: {n_conf_states}') 
+    
+    if transition_list is None:
+        # Compute all transitions:
+        transition_list = []
+        for m in range(n_conf_states):
+            for n in range(m+1,n_conf_states):
+                transition_list.append(f'{m}_{n}')
+                
+    elif type(transition_list) == str:
+        # Convert to list if a single string:
+        if type(transition_list) == str:
+            transition_list = transition_list.split()           
+    
+    print(f'transitions: {transition_list}') 
+    
+    for m in range(n_conf_states):
+        for n in range(m+1,n_conf_states):
+            if f'{m}_{n}' in transition_list:
+                num_confs[f'{m}_{n}'] = 0
+                den_confs[f'{m}_{n}'] = 0
+
+    # Loop over the conformational transitions:    
+    for frame in range(len(array_folded_states)):
+        # Sum the weighted energies for partial contact fraction eval:
+        # These expectations are for Q in the subset of states (m,n)
+        for m in range(n_conf_states):
+            for n in range(m+1,n_conf_states):
+                if f'{m}_{n}' in transition_list:
+                    if array_folded_states[frame] == m or array_folded_states[frame] == n:
+                        num_confs[f'{m}_{n}'] += w_nk[frame,:]*Q[frame]
+                        den_confs[f'{m}_{n}'] += w_nk[frame,:]
+                        break            
+            
+    # Now compute the final expectation values:        
+    for m in range(n_conf_states):
+        for n in range(m+1,n_conf_states):
+            if f'{m}_{n}' in transition_list:
+                Q_expect_confs[f'{m}_{n}'] = num_confs[f'{m}_{n}']/den_confs[f'{m}_{n}']
+
+    # ***TODO: implement uncertainty directly from the mbar algorithm
+
+    T_list_out = full_T_list*unit.kelvin
+
+    return Q_expect_confs, T_list_out
 
     
 def fraction_native_contacts(
@@ -375,7 +576,7 @@ def fraction_native_contacts(
     native_contact_tol=1.3,
     subsample=True,
     homopolymer_sym=False,
-):
+    ):
     """
     Given a cgmodel, mdtraj trajectory object, and positions for the native structure, this function calculates the fraction of native contacts for the model.
     
@@ -428,13 +629,6 @@ def fraction_native_contacts(
     Q_avg = np.zeros((n_replicas))
     Q_stderr = np.zeros((n_replicas))
       
-    # For homopolymer symmetry, check that the chains are linear,
-    # which is the only option implemented for symmetry checks so far.
-    if homopolymer_sym:
-        if len(cgmodel.particle_type_list) > 1:
-            print(f'Error: For homopolymer symmetry checks, only linear chains with one bead type are supported')
-            exit()
-      
     for rep in range(n_replicas):            
         # This should work for pdb or dcd
         # However for dcd we need to insert a topology, and convert it from openmm->mdtraj topology 
@@ -454,16 +648,57 @@ def fraction_native_contacts(
         # This produces a [nframe x len(native_contacts)] array
         
         if homopolymer_sym:
-            # We can simply reverse the indices of the native contact list:
-            # ***TODO: allow the reversed indices to be specified explicitly.
-            # (such as if there are sidechains, or the order in the pdb file is different)
-  
+        
+            # ***Note: this assumes that the particles are indexed by monomer, and in the same
+            # order for each monomer.
+            
             n_particles = rep_traj.n_atoms
-            reverse_contact_list = []
-            for pair in native_contact_list:
-                reverse_par0 = n_particles-pair[0]-1
-                reverse_par1 = n_particles-pair[1]-1
-                reverse_contact_list.append([reverse_par0, reverse_par1])
+            reverse_contact_list = []            
+            
+            if len(cgmodel.particle_type_list) == 1:
+                # We can simply reverse the indices of the native contact list:
+      
+                for pair in native_contact_list:
+                    reverse_par0 = n_particles-pair[0]-1
+                    reverse_par1 = n_particles-pair[1]-1
+                    reverse_contact_list.append([reverse_par0, reverse_par1])
+                
+            else:
+                # We need to use the particle type list of the original model,
+                # and reconstruct monomer by monomer from the opposite end.
+                
+                # This should also work for 1 particle per monomer.
+                
+                particle_type_list = []
+                mono_indices_list = []
+                particle_indices_forward = []
+                particle_indices_reverse = []
+
+                for p in range(n_particles):
+                    particle_indices_forward.append(p)
+                    particle_type_list.append(cgmodel.get_particle_type_name(p))
+                    mono_indices_list.append(cgmodel.get_particle_monomer(p))
+                
+                n_particles_per_mono = 0
+                
+                for p in range(n_particles):
+                    if cgmodel.get_particle_monomer(p) == 0:
+                        n_particles_per_mono += 1
+                    else:
+                        break
+                
+                n_mono = int(n_particles/n_particles_per_mono)
+                
+                for m in range(n_mono):
+                    for p in range(n_particles_per_mono):
+                        particle_indices_reverse = n_particles - n_particles_per_mono*(m+1) - p
+                        # For example, if forward indices [0,1] is [bb,sc] with 84 total particles, then [82,83] is the reverse
+                
+                # Now select the contact pairs:
+                for pair in native_contact_list:
+                    reverse_par0 = particle_indices_reverse[pair[0]]
+                    reverse_par1 = particle_indices_reverse[pair[1]]
+                    reverse_contact_list.append([reverse_par0, reverse_par1])
                 
             reverse_distances = md.compute_distances(
                 rep_traj,reverse_contact_list,periodic=False,opt=True)
@@ -588,16 +823,57 @@ def fraction_native_contacts_preloaded(
         # This produces a [nframe x len(native_contacts)] array
         
         if homopolymer_sym:
-            # We can simply reverse the indices of the native contact list:
-            # ***TODO: allow the reversed indices to be specified explicitly.
-            # (such as if there are sidechains, or the order in the pdb file is different)
-  
-            n_particles = traj_dict[rep].n_atoms
-            reverse_contact_list = []
-            for pair in native_contact_list:
-                reverse_par0 = n_particles-pair[0]-1
-                reverse_par1 = n_particles-pair[1]-1
-                reverse_contact_list.append([reverse_par0, reverse_par1])
+        
+            # ***Note: this assumes that the particles are indexed by monomer, and in the same
+            # order for each monomer.
+            
+            n_particles = rep_traj.n_atoms
+            reverse_contact_list = []            
+            
+            if len(cgmodel.particle_type_list) == 1:
+                # We can simply reverse the indices of the native contact list:
+      
+                for pair in native_contact_list:
+                    reverse_par0 = n_particles-pair[0]-1
+                    reverse_par1 = n_particles-pair[1]-1
+                    reverse_contact_list.append([reverse_par0, reverse_par1])
+                
+            else:
+                # We need to use the particle type list of the original model,
+                # and reconstruct monomer by monomer from the opposite end.
+                
+                # This should also work for 1 particle per monomer.
+                
+                particle_type_list = []
+                mono_indices_list = []
+                particle_indices_forward = []
+                particle_indices_reverse = []
+
+                for p in range(n_particles):
+                    particle_indices_forward.append(p)
+                    particle_type_list.append(cgmodel.get_particle_type_name(p))
+                    mono_indices_list.append(cgmodel.get_particle_monomer(p))
+                
+                n_particles_per_mono = 0
+                
+                for p in range(n_particles):
+                    if cgmodel.get_particle_monomer(p) == 0:
+                        n_particles_per_mono += 1
+                    else:
+                        break
+                
+                n_mono = int(n_particles/n_particles_per_mono)
+                
+                for m in range(n_mono):
+                    for p in range(n_particles_per_mono):
+                        particle_indices_reverse = n_particles - n_particles_per_mono*(m+1) - p
+                        # For example, if forward indices [0,1] is [bb,sc] with 84 total particles, then [82,83] is the reverse
+                
+                # Now select the contact pairs:
+                for pair in native_contact_list:
+                    reverse_par0 = particle_indices_reverse[pair[0]]
+                    reverse_par1 = particle_indices_reverse[pair[1]]
+                    reverse_contact_list.append([reverse_par0, reverse_par1])
                 
             reverse_distances = md.compute_distances(
                 traj_dict[rep][frame_begin:],reverse_contact_list,periodic=False,opt=True)
@@ -723,13 +999,6 @@ def optimize_Q_cut(
         # Convert to a 1 element list if not one
         traj_file_list = traj_file_list.split()  
         n_replicas = 1
-    
-    # For homopolymer symmetry, check that the chains are linear,
-    # which is the only option implemented for symmetry checks so far.    
-    if homopolymer_sym:
-        if len(cgmodel.particle_type_list) > 1:
-            print(f'Error: For homopolymer symmetry checks, only linear chains with one bead type are supported')
-            exit()    
         
     for rep in range(n_replicas):
         if traj_file_list[rep][-3:] == 'dcd':
@@ -966,14 +1235,7 @@ def optimize_Q_cut_1d(
         # Convert to a 1 element list if not one
         traj_file_list = traj_file_list.split()  
         n_replicas = 1
-      
-    # For homopolymer symmetry, check that the chains are linear,
-    # which is the only option implemented for symmetry checks so far.      
-    if homopolymer_sym:
-        if len(cgmodel.particle_type_list) > 1:
-            print(f'Error: For homopolymer symmetry checks, only linear chains with one bead type are supported')
-            exit()
-      
+        
     for rep in range(n_replicas):
         if traj_file_list[rep][-3:] == 'dcd':
             traj_dict[rep] = md.load(traj_file_list[rep],top=md.Topology.from_openmm(cgmodel.topology))
@@ -1194,13 +1456,6 @@ def bootstrap_native_contacts_expectation(
         # Convert to a 1 element list if not one
         traj_file_list = traj_file_list.split()  
         n_replicas = 1
-      
-    # For homopolymer symmetry, check that the chains are linear,
-    # which is the only option implemented for symmetry checks so far.      
-    if homopolymer_sym:
-        if len(cgmodel.particle_type_list) > 1:
-            print(f'Error: For homopolymer symmetry checks, only linear chains with one bead type are supported')
-            exit()        
         
     for rep in range(n_replicas):
         if traj_file_list[rep][-3:] == 'dcd':
@@ -1419,6 +1674,366 @@ def bootstrap_native_contacts_expectation(
     return temp_list, Q_values, Q_uncertainty, sigmoid_results_boot
     
     
+def bootstrap_partial_contacts_expectation(
+    cgmodel,
+    traj_file_list,
+    native_contact_list,
+    native_contact_distances,
+    array_folded_states,
+    output_data='output/output.nc',
+    frame_begin=0,
+    sample_spacing=1,
+    native_contact_tol=1.3,
+    num_intermediate_states=0,
+    n_trial_boot=200,
+    conf_percent='sigma',
+    plotfile='Q_vs_T_bootstrap.pdf',
+    homopolymer_sym=False,
+    transition_list=None,
+    ):
+    """
+    Given a cgmodel, native contact definitions, and trajectory file list, this function calculates the
+    fraction of native contacts for all specified frames, and uses a bootstrapping scheme to compute
+    the uncertainties in the Q vs T folding curve. Intended to be used after the native contact tolerance
+    has been optimized (either the helical or generalized versions).
+    
+    Here the partial contact fractions are computed, using only the structures classified within a pair of conformations.
+    
+    :param cgmodel: CGModel() class object
+    :type cgmodel: class
+        
+    :param traj_file_list: A list of replica PDB or DCD trajectory files corresponding to the energies in the .nc file, or a single file name
+    :type traj_file_list: List( str ) or str
+
+    :param native_contact_list: A list of the nonbonded interactions whose inter-particle distances are less than the 'native_contact_distance_cutoff'.
+    :type native_contact_list: List
+    
+    :param native_contact_distances: A numpy array of the native pairwise distances corresponding to native_contact_list
+    :type native_contact_distances: Quantity
+
+    :param array_folded_states: a precomputed array classifying the different conformational states
+    :type array_folded_states: 2d numpy array (int)   
+
+    :param frame_begin: Frame at which to start native contacts analysis (default=0)
+    :type frame_begin: int
+    
+    :param sample_spacing: spacing of uncorrelated data points, for example determined from pymbar timeseries subsampleCorrelatedData (default=1)
+    :type sample_spacing: int
+    
+    :param native_contact_tol: Tolerance factor beyond the native distance for determining whether a pair of particles is 'native' (in multiples of native distance) (default=1.3)
+    :type native_contact_tol: float
+    
+    :param num_intermediate_states: The number of states to insert between existing simulated temperature states (default=0)
+    :type num_intermediate_states: int
+    
+    :param n_trial_boot: number of trials to run for generating bootstrapping uncertainties (default=200)
+    :type n_trial_boot: int
+    
+    :param conf_percent: Confidence level in percent for outputting uncertainties (default='sigma'=68.27)
+    :type conf_percent: float
+    
+    :param plotfile: Path to output file for plotting results (default='Q_vs_T_bootstrap.pdf')
+    :type plotfile: str
+    
+    :param homopolymer_sym: if there is end-to-end symmetry, scan forwards and backwards sequences for highest Q (default=False)
+    :type homopolymer_sym: Boolean    
+    
+    :returns:
+       - temp_list ( List( float * unit.simtk.temperature ) ) - The temperature list corresponding to the native contact fraction values
+       - Q_values ( List( float ) ) - The native contact fraction values for all (including inserted intermediates) states
+       - Q_uncertainty ( Tuple ( np.array(float) ) - confidence interval for all Q_values computed from bootstrapping
+       - sigmoid_results_boot ( dict ) - dictionary containing the 4 sigmoid parameters and Q_folded (and their confidence interval tuples)
+    """
+    
+    # Pre-load the replica trajectories into MDTraj objects, to avoid having to load them
+    # at each iteration (very costly for pdb in particular)
+    
+    traj_dict = {}
+    
+    if type(traj_file_list) == list:
+        n_replicas = len(traj_file_list)
+    elif type(traj_file_list) == str:
+        # Convert to a 1 element list if not one
+        traj_file_list = traj_file_list.split()  
+        n_replicas = 1
+        
+    for rep in range(n_replicas):
+        if traj_file_list[rep][-3:] == 'dcd':
+            traj_dict[rep] = md.load(traj_file_list[rep],top=md.Topology.from_openmm(cgmodel.topology))
+        else:
+            traj_dict[rep] = md.load(traj_file_list[rep])    
+   
+    # Extract reduced energies and the state indices from the .nc
+    reporter = MultiStateReporter(output_data, open_mode="r")
+    analyzer = ReplicaExchangeAnalyzer(reporter)
+    (
+        replica_energies_all,
+        unsampled_state_energies,
+        neighborhoods,
+        replica_state_indices,
+    ) = analyzer.read_energies()   
+   
+    reporter.close()          
+            
+    # Get native contact fraction of all frames (bootstrapping draws uncorrelated samples from this full dataset)
+    # To avoid loading in files each iteration, use alternate version of fraction_native_contacts code
+    Q_all, Q_avg, Q_stderr, decorrelation_time = fraction_native_contacts_preloaded(
+        cgmodel,
+        traj_dict,
+        native_contact_list,
+        native_contact_distances,
+        frame_begin=frame_begin,
+        native_contact_tol=native_contact_tol,
+        subsample=False,
+        homopolymer_sym=homopolymer_sym,
+    )
+    
+    # Check the size of array_folded_states:
+    if np.shape(replica_energies_all[:,:,frame_begin::])[2] != np.shape(array_folded_states)[0]:
+        print(f'Error: mismatch in number of samples in array_folded_states and specified frames of replica energies')
+        exit()    
+    
+    # Get the number of conformational state classifications:
+    n_conf_states = len(np.unique(array_folded_states))      
+    
+    if transition_list is None:
+        # Compute all transitions:
+        transition_list = []
+        for m in range(n_conf_states):
+            for n in range(m+1,n_conf_states):
+                transition_list.append(f'{m}_{n}')
+                
+    elif type(transition_list) == str:
+        # Convert to list if a single string:
+        if type(transition_list) == str:
+            transition_list = transition_list.split()                      
+                
+    # For each bootstrap trial, compute the expectation of native contacts and fit to sigmoid.
+    Q_expect_boot = {}
+    
+    sigmoid_Q_max = {}
+    sigmoid_Q_min = {}
+    sigmoid_d = {}
+    sigmoid_Tm = {}
+    Q_folded = {}
+    
+    for trans in transition_list:
+        sigmoid_Q_max[trans] = np.zeros(n_trial_boot)
+        sigmoid_Q_min[trans] = np.zeros(n_trial_boot)
+        sigmoid_d[trans] = np.zeros(n_trial_boot)
+        sigmoid_Tm[trans] = np.zeros(n_trial_boot)
+        Q_folded[trans] = np.zeros(n_trial_boot)
+    
+    for i_boot in range(n_trial_boot):
+        # Select production frames to analyze
+        # Here we can potentially change the reference frame for each bootstrap trial.
+        ref_shift = np.random.randint(sample_spacing)
+        # ***We should check if these energies arrays will be the same size for
+        # different reference frames
+        replica_energies = replica_energies_all[:,:,(frame_begin+ref_shift)::sample_spacing]
+        array_folded_states_boot = array_folded_states[ref_shift::sample_spacing,:]
+        # ***Unlike replica energies, Q does not include the equilibration frames
+        Q = Q_all[ref_shift::sample_spacing,:]
+        
+        # Get all possible sample indices
+        sample_indices_all = np.arange(0,len(replica_energies[0,0,:]))
+        # n_samples should match the size of the sliced replica energy dataset
+        sample_indices = resample(sample_indices_all, replace=True, n_samples=len(sample_indices_all))
+        
+        n_state = replica_energies.shape[0]
+        
+        replica_energies_resample = np.zeros_like(replica_energies)
+        # replica_energies is [n_states x n_states x n_frame]
+        # Q and array_folded_states are [nframes x n_replicas]
+        Q_resample = np.zeros((len(sample_indices),n_replicas))
+        array_folded_states_resample = np.zeros_like(array_folded_states_boot)
+        
+        # Select the sampled frames from array_folded_states and replica_energies:
+        j = 0
+        for i in sample_indices:
+            replica_energies_resample[:,:,j] = replica_energies[:,:,i]
+            array_folded_states_resample[j,:] = array_folded_states_boot[i,:]
+            Q_resample[j,:] = Q[i,:]
+            j += 1
+            
+        # Run the native contacts expectation calculation:
+        # Q_expect_boot is nested dict with keys [i_boot]['m_n']
+        Q_expect_boot[i_boot], T_list_out = expectations_partial_contact_fractions(
+            array_folded_states_resample,
+            Q_resample,
+            frame_begin=frame_begin,
+            num_intermediate_states=num_intermediate_states,
+            bootstrap_energies=replica_energies_resample,
+            output_data=output_data,
+            transition_list=transition_list,
+        )
+        
+        # Fit contact fraction vs T for each transition to sigmoid:
+        for trans in transition_list:
+            param_opt, param_cov = fit_sigmoid(
+                T_list_out,
+                Q_expect_boot[i_boot][trans],
+                plotfile=None
+                )
+        
+            # Save the individual parameters:
+            # These have the reversed order of keys:
+            if param_opt[1] >= param_opt[2]:
+                sigmoid_Q_max[trans][i_boot] = param_opt[1]
+                sigmoid_Q_min[trans][i_boot] = param_opt[2]
+            else:
+                # This shouldn't occur unless d is negative
+                print(f'Error with sigmoid fitting')
+                sigmoid_Q_max[trans][i_boot] = param_opt[2]
+                sigmoid_Q_min[trans][i_boot] = param_opt[1]
+                
+            sigmoid_d[trans][i_boot] = param_opt[3]
+            sigmoid_Tm[trans][i_boot] = param_opt[0]
+            Q_folded[trans][i_boot] = (param_opt[1]+param_opt[2])/2
+        
+    # Compute uncertainty at all temps in Q_expect_boot over the n_trial_boot trials performed:
+    
+    # Total number of temps including intermediate states: 
+    n_temps = len(T_list_out)
+    
+    # Convert bootstrap trial dicts to array
+    arr_Q_values_boot = {}
+    
+    for trans in transition_list:
+        arr_Q_values_boot[trans] = np.zeros((n_trial_boot, n_temps))
+    
+        for i_boot in range(n_trial_boot):
+            arr_Q_values_boot[trans][i_boot,:] = Q_expect_boot[i_boot][trans]
+            
+    # Compute mean values:
+
+    Q_values = {}
+    sigmoid_Q_max_value = {}
+    sigmoid_Q_min_value = {}
+    sigmoid_d_value = {}
+    sigmoid_Tm_value = {}
+    Q_folded_value = {}
+    
+    for trans in transition_list:
+        Q_values[trans] = np.mean(arr_Q_values_boot[trans],axis=0)
+        sigmoid_Q_max_value[trans] = np.mean(sigmoid_Q_max[trans])
+        sigmoid_Q_min_value[trans] = np.mean(sigmoid_Q_min[trans])
+        sigmoid_d_value[trans] = np.mean(sigmoid_d[trans])*unit.kelvin
+        sigmoid_Tm_value[trans] = np.mean(sigmoid_Tm[trans])*unit.kelvin
+        Q_folded_value[trans] = np.mean(Q_folded[trans])
+    
+    # Compute confidence intervals:
+    Q_uncertainty = {}
+    sigmoid_Q_max_uncertainty = {}
+    sigmoid_Q_min_uncertainty = {}
+    sigmoid_d_uncertainty = {}
+    sigmoid_Tm_uncertainty = {}
+    Q_folded_uncertainty = {}
+    
+    if conf_percent == 'sigma':
+        # Use analytical standard deviation instead of percentile method:
+        
+        for trans in transition_list:
+            # Q values:
+            Q_std = np.std(arr_Q_values_boot[trans],axis=0)
+            Q_uncertainty[trans] = (-Q_std, Q_std)
+            
+            # Sigmoid Q_max:
+            sigmoid_Q_max_std = np.std(sigmoid_Q_max[trans])
+            sigmoid_Q_max_uncertainty[trans] = (-sigmoid_Q_max_std, sigmoid_Q_max_std)   
+            
+            # Sigmoid Q_min:
+            sigmoid_Q_min_std = np.std(sigmoid_Q_min[trans])
+            sigmoid_Q_min_uncertainty[trans] = (-sigmoid_Q_min_std, sigmoid_Q_min_std) 
+
+            # Sigmoid d:
+            sigmoid_d_std = np.std(sigmoid_d[trans])
+            sigmoid_d_uncertainty[trans] = (-sigmoid_d_std*unit.kelvin, sigmoid_d_std*unit.kelvin)
+            
+            # Sigmoid Tm:
+            sigmoid_Tm_std = np.std(sigmoid_Tm[trans])
+            sigmoid_Tm_uncertainty[trans] = (-sigmoid_Tm_std*unit.kelvin, sigmoid_Tm_std*unit.kelvin)
+            
+            # Q_folded:
+            Q_folded_std = np.std(Q_folded[trans])
+            Q_folded_uncertainty[trans] = (-Q_folded_std, Q_folded_std)
+        
+    else:
+        # Compute specified confidence interval:
+        p_lo = (100-conf_percent)/2
+        p_hi = 100-p_lo
+                
+        for trans in transition_list:        
+            # Q values:
+            Q_diff = arr_Q_values_boot[trans]-np.mean(arr_Q_values_boot[trans],axis=0)
+            Q_conf_lo = np.percentile(Q_diff,p_lo,axis=0,interpolation='linear')
+            Q_conf_hi = np.percentile(Q_diff,p_hi,axis=0,interpolation='linear')
+          
+            Q_uncertainty[trans] = (Q_conf_lo, Q_conf_hi) 
+                        
+            # Sigmoid Q_max:
+            sigmoid_Q_max_diff = sigmoid_Q_max[trans]-np.mean(sigmoid_Q_max[trans])
+            sigmoid_Q_max_conf_lo = np.percentile(sigmoid_Q_max_diff,p_lo,interpolation='linear')
+            sigmoid_Q_max_conf_hi = np.percentile(sigmoid_Q_max_diff,p_hi,interpolation='linear')
+            
+            sigmoid_Q_max_uncertainty[trans] = (sigmoid_Q_max_conf_lo, sigmoid_Q_max_conf_hi)
+            
+            # Sigmoid Q_min:
+            sigmoid_Q_min_diff = sigmoid_Q_min[trans]-np.mean(sigmoid_Q_min[trans])
+            sigmoid_Q_min_conf_lo = np.percentile(sigmoid_Q_min_diff,p_lo,interpolation='linear')
+            sigmoid_Q_min_conf_hi = np.percentile(sigmoid_Q_min_diff,p_hi,interpolation='linear')
+            
+            sigmoid_Q_min_uncertainty[trans] = (sigmoid_Q_min_conf_lo, sigmoid_Q_min_conf_hi)
+            
+            # Sigmoid d:
+            sigmoid_d_diff = sigmoid_d[trans]-np.mean(sigmoid_d[trans])
+            sigmoid_d_conf_lo = np.percentile(sigmoid_d_diff,p_lo,interpolation='linear')
+            sigmoid_d_conf_hi = np.percentile(sigmoid_d_diff,p_hi,interpolation='linear')
+            
+            sigmoid_d_uncertainty[trans] = (sigmoid_d_conf_lo*unit.kelvin, sigmoid_d_conf_hi*unit.kelvin)
+            
+            # Sigmoid Tm:
+            sigmoid_Tm_diff = sigmoid_Tm[trans]-np.mean(sigmoid_Tm[trans])
+            sigmoid_Tm_conf_lo = np.percentile(sigmoid_Tm_diff,p_lo,interpolation='linear')
+            sigmoid_Tm_conf_hi = np.percentile(sigmoid_Tm_diff,p_hi,interpolation='linear')
+            
+            sigmoid_Tm_uncertainty[trans] = (sigmoid_Tm_conf_lo*unit.kelvin, sigmoid_Tm_conf_hi*unit.kelvin)
+            
+            # Q_folded:
+            Q_folded_diff = Q_folded[trans]-np.mean(Q_folded[trans])
+            Q_folded_conf_lo = np.percentile(Q_folded_diff,p_lo,interpolation='linear')
+            Q_folded_conf_hi = np.percentile(Q_folded_diff,p_hi,interpolation='linear')
+            
+            Q_folded_uncertainty[trans] = (Q_folded_conf_lo, Q_folded_conf_hi*unit.kelvin)      
+    
+    # Compile sigmoid results into dict of dicts:
+    sigmoid_results_boot = {}
+    
+    sigmoid_results_boot['sigmoid_Q_max_value'] = sigmoid_Q_max_value
+    sigmoid_results_boot['sigmoid_Q_max_uncertainty'] = sigmoid_Q_max_uncertainty
+    
+    sigmoid_results_boot['sigmoid_Q_min_value'] = sigmoid_Q_min_value
+    sigmoid_results_boot['sigmoid_Q_min_uncertainty'] = sigmoid_Q_min_uncertainty
+    
+    sigmoid_results_boot['sigmoid_d_value'] = sigmoid_d_value
+    sigmoid_results_boot['sigmoid_d_uncertainty'] = sigmoid_d_uncertainty
+    
+    sigmoid_results_boot['sigmoid_Tm_value'] = sigmoid_Tm_value
+    sigmoid_results_boot['sigmoid_Tm_uncertainty'] = sigmoid_Tm_uncertainty
+    
+    sigmoid_results_boot['Q_folded_value'] = Q_folded_value
+    sigmoid_results_boot['Q_folded_uncertainty'] = Q_folded_uncertainty
+    
+    # Plot Q vs T results with uncertainty and mean sigmoid parameters
+    if conf_percent=='sigma':
+        plot_partial_contact_fractions(
+            T_list_out, Q_values, Q_std, plotfile=plotfile, sigmoid_dict=sigmoid_results_boot
+            )
+    # TODO: implement unequal upper and lower error plotting
+    
+    return T_list_out, Q_values, Q_uncertainty, sigmoid_results_boot    
+    
+    
 def optimize_Q_tol_helix(
     cgmodel, native_structure_file, traj_file_list, output_data="output/output.nc",
     num_intermediate_states=0, frame_begin=0, frame_stride=1, backbone_type_name='bb',
@@ -1485,14 +2100,7 @@ def optimize_Q_tol_helix(
         # Convert to a 1 element list if not one
         traj_file_list = traj_file_list.split()  
         n_replicas = 1
-     
-    # For homopolymer symmetry, check that the chains are linear,
-    # which is the only option implemented for symmetry checks so far.     
-    if homopolymer_sym:
-        if len(cgmodel.particle_type_list) > 1:
-            print(f'Error: For homopolymer symmetry checks, only linear chains with one bead type are supported')
-            exit()
-     
+        
     for rep in range(n_replicas):
         if traj_file_list[rep][-3:] == 'dcd':
             traj_dict[rep] = md.load(traj_file_list[rep],top=md.Topology.from_openmm(cgmodel.topology))
@@ -1721,6 +2329,130 @@ def plot_native_contact_fraction(temperature_list, Q, Q_uncertainty, plotfile="Q
     plt.ylabel("Native contact fraction")
     plt.savefig(plotfile)
     plt.close()
+    
+    
+def plot_partial_contact_fractions(temperature_list, Q_values, Q_uncertainty, plotfile="partial_Q_vs_T.pdf", sigmoid_dict=None):
+    """
+    Given a list of temperatures and corresponding partial contact fractions, plot Q vs T for each transition.
+    If a sigmoid dict from bootstrapping is given, also plot the sigmoid curve.
+    Note that this sigmoid curve is generated by using the mean values of the 4 hyperbolic fitting parameters
+    taken over all bootstrap trials, not a direct fit to the Q vs T data. 
+
+    :param temperature_list: List of temperatures that will be used to define different replicas (thermodynamics states)
+    :type temperature_list: List( `SIMTK <https://simtk.org/>`_ `Unit() <http://docs.openmm.org/7.1.0/api-python/generated/simtk.unit.unit.Unit.html>`_ * number_replicas )
+
+    :param Q: native contact fraction array for all temperatures in temperature_list
+    :type Q: np.array(float * len(temperature_list))
+    
+    :param Q_uncertainty: uncertainty associated with Q
+    :type Q_uncertainty: np.array(float * len(temperature_list))
+    
+    :param plotfile: Path to output file for plotting results (default='Q_vs_T.pdf')
+    :type plotfile: str
+    
+    :param sigmoid_dict: dictionary containing sigmoid parameter mean values and uncertainties (default=None)
+    :type sigmoid_dict: dict
+    """
+
+    temperature_array = np.zeros((len(temperature_list)))
+    for i in range(len(temperature_list)):
+        temperature_array[i] = temperature_list[i].value_in_unit(unit.kelvin)
+    
+    if sigmoid_dict is not None:
+        # Also plot sigmoid curve
+        def tanh_switch(x,x0,y0,y1,d):
+            return (y0+y1)/2-((y0-y1)/2)*np.tanh(np.radians(x-x0)/d)
+        
+        for trans, value in Q_values.items():
+            xsig = np.linspace(temperature_array[0],temperature_array[-1],1000)
+            ysig = tanh_switch(
+                xsig,
+                sigmoid_dict['sigmoid_Tm_value'][trans].value_in_unit(unit.kelvin),
+                sigmoid_dict['sigmoid_Q_max_value'][trans],
+                sigmoid_dict['sigmoid_Q_min_value'][trans],
+                sigmoid_dict['sigmoid_d_value'][trans].value_in_unit(unit.kelvin),
+                )
+            
+            
+            errorbar1 = plt.errorbar(
+                temperature_array,
+                Q_values[trans],
+                yerr=Q_uncertainty,
+                linewidth=0.5,
+                markersize=4,
+                fmt='o',
+                label=f'trans {trans} mean',
+                fillstyle='none',
+                capsize=4,
+            )
+            
+            # Get the color of the errorbar:
+            lines_tuple = errorbar1.lines
+            # This contains (data_line(Line2D), caplines(Line2D), barlinecols(LineCollection))
+            color1 = lines_tuple[0].get_color()
+            
+            line2 = plt.plot(
+                xsig, ysig,'-',
+                label=f'trans {trans} fit',
+                color=color1, # keep the same color
+            )
+            
+            line3 = plt.errorbar(
+                sigmoid_dict['sigmoid_Tm_value'][trans].value_in_unit(unit.kelvin),
+                sigmoid_dict['Q_folded_value'][trans],
+                xerr=sigmoid_dict['sigmoid_Tm_uncertainty'][trans][1].value_in_unit(unit.kelvin),
+                yerr=sigmoid_dict['Q_folded_uncertainty'][trans][1],
+                linewidth=0.5,
+                markersize=4,
+                fmt='D-r',
+                fillstyle='none',
+                capsize=4,
+            )
+            
+            xlim = plt.xlim()
+            ylim = plt.ylim()        
+            
+            # TODO: update to use the asymmetric uncertainties here for confidence intervals
+            # We can add the hyperbolic fits with parameters for the upper and lower confidence bounds
+            # plt.text(
+                # (xlim[0]+0.90*(xlim[1]-xlim[0])),
+                # (ylim[0]+0.50*(ylim[1]-ylim[0])),
+                # f"T_m = {sigmoid_dict['sigmoid_Tm_value'].value_in_unit(unit.kelvin):.2f} \u00B1 {sigmoid_dict['sigmoid_Tm_uncertainty'][1].value_in_unit(unit.kelvin):.2f}    \n"\
+                # f"Q_m = {sigmoid_dict['Q_folded_value']:.4f} \u00B1 {sigmoid_dict['Q_folded_uncertainty'][1]:.4f}\n"\
+                # f"d = {sigmoid_dict['sigmoid_d_value'].value_in_unit(unit.kelvin):.4f} \u00B1 {sigmoid_dict['sigmoid_d_uncertainty'][1].value_in_unit(unit.kelvin):.4f}\n"\
+                # f"Qmax = {sigmoid_dict['sigmoid_Q_max_value']:.4f} \u00B1 {sigmoid_dict['sigmoid_Q_max_uncertainty'][1]:.4f}\n"\
+                # f"Qmin = {sigmoid_dict['sigmoid_Q_min_value']:.4f} \u00B1 {sigmoid_dict['sigmoid_Q_min_uncertainty'][1]:.4f}",
+                # {'fontsize': 10},
+                # horizontalalignment='right',
+                # )
+
+    else:
+        for trans, value in Q_values.items():
+            plt.errorbar(
+                temperature_array,
+                Q_values[trans],
+                Q_uncertainty[trans],
+                linewidth=0.5,
+                markersize=4,
+                label=f'trans {trans}',
+                fmt='o-',
+                fillstyle='none',
+                capsize=4,
+            )
+            
+    plt.legend(
+        loc='upper right',
+        fontsize=6,
+        )
+
+    # Fix y limits:
+    plt.xlim((temperature_array[0],temperature_array[-1]))
+    plt.ylim((0,1))
+    
+    plt.xlabel("T (K)")
+    plt.ylabel("Contact fraction")
+    plt.savefig(plotfile)
+    plt.close()    
     
     
 def plot_native_contact_timeseries(

--- a/cg_openmm/tests/test_energy_eval.py
+++ b/cg_openmm/tests/test_energy_eval.py
@@ -18,7 +18,40 @@ import pickle
     
 current_path = os.path.dirname(os.path.abspath(__file__))
 data_path = os.path.join(current_path, 'test_data')
-       
+structures_path = os.path.join(current_path, 'test_structures')
+
+def test_energy_decomposition_dcd(tmpdir):  
+    """
+    Test the energy decomposition on a cgmodel and medoid, and check that the individual components
+    sum to the total potential energy.
+    """
+    
+    output_directory = tmpdir.mkdir("output")
+    
+    # Load in cgmodel
+    cgmodel = pickle.load(open(f"{data_path}/stored_cgmodel.pkl", "rb" ))
+    
+    # Set path to medoid structure file:
+    medoid_file = f"{structures_path}/medoid_min.dcd"
+    
+    # Run the energy decomposition:
+    U_decomposition = energy_decomposition(
+        cgmodel,
+        medoid_file,
+    )
+    
+    # Check the sum of energy components:
+    sum_expected = U_decomposition['total']
+    sum_actual = 0 * unit.kilojoule_per_mole
+    
+    print(U_decomposition)
+    
+    for key,value in U_decomposition.items():
+        if key != 'total':
+            sum_actual += value
+    
+    assert sum_expected == sum_actual
+
     
 def test_eval_energy_no_change(tmpdir):  
     """

--- a/cg_openmm/tests/test_native_contacts.py
+++ b/cg_openmm/tests/test_native_contacts.py
@@ -133,10 +133,11 @@ def test_native_contacts_dcd(tmpdir):
     assert os.path.isfile(f"{output_directory}/Q_vs_T.pdf")
     
     
-def test_native_contacts_dcd_homopolymer_sym(tmpdir):
+def test_native_contacts_dcd_homopolymer_sym_linear(tmpdir):
     """
     Test native contact fraction calculation with homopolymer
     end-to-end symmetry checks.
+    (linear homopolymer with no sidechains)
     """
     
     output_directory = tmpdir.mkdir("output")
@@ -156,6 +157,68 @@ def test_native_contacts_dcd_homopolymer_sym(tmpdir):
         
     # Set path to native structure file:    
     native_structure_file=f"{data_path_linear}/native_medoid_min.dcd"
+    
+    # Set cutoff parameters:
+    # Cutoff for native structure pairwise distances:
+    native_contact_cutoff = 4.0* unit.angstrom
+
+    # Tolerance for current trajectory distances:
+    native_contact_tol = 1.5
+    
+    # Determine native contacts:
+    native_contact_list, native_contact_distances, contact_type_dict = get_native_contacts(
+        cgmodel,
+        native_structure_file,
+        native_contact_cutoff,
+    )
+    
+    # Determine native contact fraction of current trajectories:
+    # With end-to-end symmetry check:
+    Q_sym, Q_avg_sym, Q_stderr_sym, decorrelation_spacing_sym = fraction_native_contacts(
+        cgmodel,
+        dcd_file_list,
+        native_contact_list,
+        native_contact_distances,
+        native_contact_tol=native_contact_tol,
+        homopolymer_sym=True,
+    )   
+    
+    # Without end-to-end symmetry check:
+    Q, Q_avg, Q_stderr, decorrelation_spacing = fraction_native_contacts(
+        cgmodel,
+        dcd_file_list,
+        native_contact_list,
+        native_contact_distances,
+        native_contact_tol=native_contact_tol,
+        homopolymer_sym=False,
+    )      
+
+    # End-to-end symmetry check should increase the contact fraction in all cases:
+    assert Q_sym.all() >= Q.all()
+
+
+def test_native_contacts_dcd_homopolymer_sym_sidechain(tmpdir):
+    """
+    Test native contact fraction calculation with homopolymer
+    end-to-end symmetry checks.
+    (1-1 homopolymer model with sidechains)
+    """
+    
+    output_directory = tmpdir.mkdir("output")
+    
+    # Replica exchange settings
+    number_replicas = 12
+    
+    # Load in cgmodel
+    cgmodel = pickle.load(open(f"{data_path}/stored_cgmodel.pkl", "rb" ))
+    
+    # Create list of dcd trajectories to analyze
+    dcd_file_list = []
+    for i in range(number_replicas):
+        dcd_file_list.append(f"{data_path}/replica_{i+1}.dcd")
+        
+    # Set path to native structure file:    
+    native_structure_file=f"{structures_path}/medoid_0.dcd"
     
     # Set cutoff parameters:
     # Cutoff for native structure pairwise distances:
@@ -472,10 +535,85 @@ def test_expectations_fraction_contacts_dcd(tmpdir):
     assert os.path.isfile(f"{output_directory}/Q_vs_T_fit.pdf")
     
     
+def test_expectations_partial_contact_fractions_1state(tmpdir):
+    """
+    Test the partial contact fraction expectation code for the trivial case 
+    of a 1 state system (should match the original expectation native contact fraction result)
+    """
+
+    output_directory = tmpdir.mkdir("output")
+
+    # Replica exchange settings
+    number_replicas = 12
+    min_temp = 200.0 * unit.kelvin
+    max_temp = 600.0 * unit.kelvin
+    temperature_list = get_temperature_list(min_temp, max_temp, number_replicas)
+
+    # Load in cgmodel
+    cgmodel = pickle.load(open(f"{data_path}/stored_cgmodel.pkl", "rb" ))
+
+    # Create list of pdb trajectories to analyze
+    # For expectation fraction native contacts, we use replica trajectories: 
+    dcd_file_list = []
+    for i in range(len(temperature_list)):
+        dcd_file_list.append(f"{data_path}/replica_{i+1}.dcd")
+        
+    # Load in native structure file:    
+    native_structure_file=f"{structures_path}/medoid_0.dcd"
+
+    # Set cutoff parameters:
+    # Cutoff for native structure pairwise distances:
+    native_contact_cutoff = 4.0* unit.angstrom
+
+    # Tolerance for current trajectory distances:
+    native_contact_tol = 1.5
+
+    # Set production frames:
+    frame_begin = 100
+
+    # Get native contacts:
+    native_contact_list, native_contact_distances, contact_type_dict = get_native_contacts(
+        cgmodel,
+        native_structure_file,
+        native_contact_cutoff,
+    )
+
+    Q, Q_avg, Q_stderr, decorrelation_spacing = fraction_native_contacts(
+        cgmodel,
+        dcd_file_list,
+        native_contact_list,
+        native_contact_distances,
+        frame_begin=frame_begin,
+        native_contact_tol=native_contact_tol,
+    )
+    
+    # Set all states to be the same
+    array_folded_states = np.zeros_like(Q)
+    
+    output_data = os.path.join(data_path, "output.nc")
+    num_intermediate_states=1
+
+    Q_values_partial, T_list_out = expectations_partial_contact_fractions(
+        array_folded_states,
+        Q,
+        frame_begin=100,
+        output_data=output_data,
+        num_intermediate_states=num_intermediate_states,
+    )
+    
+    Q_results = expectations_fraction_contacts(
+        Q,
+        frame_begin=100,
+        output_data=output_data,
+        num_intermediate_states=num_intermediate_states,
+    )
+    
+    assert Q_results['Q'].all() == Q_values_partial['0'].all()
+    
+    
 def test_expectations_partial_contact_fractions_2state(tmpdir):
     """
-    Test the partial contact fraction expectation code for the trivial case 
-    of a 2 state system (should match the original expectation native contact fraction result)
+    Test the partial contact fraction expectation code for a 2 state system.
     """
 
     output_directory = tmpdir.mkdir("output")
@@ -526,7 +664,7 @@ def test_expectations_partial_contact_fractions_2state(tmpdir):
     
     # Set 1 as folded, 0 as unfolded:
     Q_folded = 0.3
-    array_folded_states = np.multiply((Q>=Q_folded),1)
+    array_folded_states = np.multiply((Q>=Q_folded),1)        
     
     output_data = os.path.join(data_path, "output.nc")
     num_intermediate_states=1
@@ -537,102 +675,16 @@ def test_expectations_partial_contact_fractions_2state(tmpdir):
         frame_begin=100,
         output_data=output_data,
         num_intermediate_states=num_intermediate_states,
-        transition_list='0_1',
     )
     
-    Q_results = expectations_fraction_contacts(
-        Q,
-        frame_begin=100,
-        output_data=output_data,
-        num_intermediate_states=num_intermediate_states,
-    )
-    
-    assert Q_results['Q'].all() == Q_values_partial['0_1'].all()
+    assert len(Q_values_partial) == 2 and type(Q_values_partial) == dict
     
     
-def test_expectations_partial_contact_fractions_2state_no_list(tmpdir):
-    """
-    Test the partial contact fraction expectation code for the trivial case 
-    of a 2 state system (should match the original expectation native contact fraction result)
-    (no transition list explicitly specified)
-    """
-
-    output_directory = tmpdir.mkdir("output")
-
-    # Replica exchange settings
-    number_replicas = 12
-    min_temp = 200.0 * unit.kelvin
-    max_temp = 600.0 * unit.kelvin
-    temperature_list = get_temperature_list(min_temp, max_temp, number_replicas)
-
-    # Load in cgmodel
-    cgmodel = pickle.load(open(f"{data_path}/stored_cgmodel.pkl", "rb" ))
-
-    # Create list of pdb trajectories to analyze
-    # For expectation fraction native contacts, we use replica trajectories: 
-    dcd_file_list = []
-    for i in range(len(temperature_list)):
-        dcd_file_list.append(f"{data_path}/replica_{i+1}.dcd")
-        
-    # Load in native structure file:    
-    native_structure_file=f"{structures_path}/medoid_0.dcd"
-
-    # Set cutoff parameters:
-    # Cutoff for native structure pairwise distances:
-    native_contact_cutoff = 4.0* unit.angstrom
-
-    # Tolerance for current trajectory distances:
-    native_contact_tol = 1.5
-
-    # Set production frames:
-    frame_begin = 100
-
-    # Get native contacts:
-    native_contact_list, native_contact_distances, contact_type_dict = get_native_contacts(
-        cgmodel,
-        native_structure_file,
-        native_contact_cutoff,
-    )
-
-    Q, Q_avg, Q_stderr, decorrelation_spacing = fraction_native_contacts(
-        cgmodel,
-        dcd_file_list,
-        native_contact_list,
-        native_contact_distances,
-        frame_begin=frame_begin,
-        native_contact_tol=native_contact_tol,
-    )
-    
-    # Set 1 as folded, 0 as unfolded:
-    Q_folded = 0.3
-    array_folded_states = np.multiply((Q>=Q_folded),1)
-    
-    output_data = os.path.join(data_path, "output.nc")
-    num_intermediate_states=1
-
-    Q_values_partial, T_list_out = expectations_partial_contact_fractions(
-        array_folded_states,
-        Q,
-        frame_begin=100,
-        output_data=output_data,
-        num_intermediate_states=num_intermediate_states,
-        transition_list=None,
-    )
-    
-    Q_results = expectations_fraction_contacts(
-        Q,
-        frame_begin=100,
-        output_data=output_data,
-        num_intermediate_states=num_intermediate_states,
-    )
-    
-    assert Q_results['Q'].all() == Q_values_partial['0_1'].all()
-    
-    
-def test_expectations_fraction_contacts_dcd_homopolymer_sym(tmpdir):
+def test_expectations_fraction_contacts_dcd_homopolymer_sym_linear(tmpdir):
     """
     See if we can determine native contacts expectations as a function of T,
     with homopolymer end-to-end symmetry checks.
+    (linear homopolymer with no sidechains)
     """
 
     output_directory = tmpdir.mkdir("output")
@@ -800,16 +852,16 @@ def test_bootstrap_partial_contacts_expectation_dcd_2state(tmpdir):
         n_trial_boot=10,
         conf_percent='sigma',
         plotfile=f'{output_directory}/partial_contacts_boot.pdf',
-        transition_list='0_1',
+        homopolymer_sym=False,
         )
         
-    assert os.path.isfile(f'{output_directory}/partial_contacts_boot.pdf')      
+    assert os.path.isfile(f'{output_directory}/partial_contacts_boot.pdf')
     
-    
-def test_bootstrap_partial_contacts_expectation_dcd_2state_no_list(tmpdir):
+
+def test_bootstrap_partial_contacts_expectation_dcd_2state_homopolymer_sym(tmpdir):
     """
     Test bootstrapping of partial native contacts expectation, based on helix contacts
-    (no transition list explicitly specified)
+    (with homopolymer symmetry check)
     """
     
     output_directory = tmpdir.mkdir("output")
@@ -874,16 +926,17 @@ def test_bootstrap_partial_contacts_expectation_dcd_2state_no_list(tmpdir):
         n_trial_boot=10,
         conf_percent='sigma',
         plotfile=f'{output_directory}/partial_contacts_boot.pdf',
-        transition_list=None,
+        homopolymer_sym=True,
         )
         
     assert os.path.isfile(f'{output_directory}/partial_contacts_boot.pdf')       
     
     
-def test_bootstrap_native_contacts_expectation_dcd_homopolymer_sym(tmpdir):
+def test_bootstrap_native_contacts_expectation_dcd_homopolymer_sym_linear(tmpdir):
     """
     Test bootstrapping of native contacts expectation, based on helix contacts,
     with homopolymer end-to-end symmetry checks.
+    (linear homopolymer with no sidechains)
     """
     
     output_directory = tmpdir.mkdir("output")
@@ -932,6 +985,59 @@ def test_bootstrap_native_contacts_expectation_dcd_homopolymer_sym(tmpdir):
         )
         
     assert os.path.isfile(f'{output_directory}/native_contacts_boot_sym.pdf')      
+    
+    
+def test_bootstrap_native_contacts_expectation_dcd_homopolymer_sym_sidechain(tmpdir):
+    """
+    Test bootstrapping of native contacts expectation, based on helix contacts,
+    with homopolymer end-to-end symmetry checks.
+    (1-1 homopolymer model with sidechains)
+    """
+    
+    output_directory = tmpdir.mkdir("output")
+    output_data = os.path.join(data_path, "output.nc")
+    
+    # Replica exchange settings
+    number_replicas = 12
+    
+    # Load in cgmodel
+    cgmodel = pickle.load(open(f"{data_path}/stored_cgmodel.pkl", "rb" ))
+    
+    # Create list of dcd trajectories to analyze
+    dcd_file_list = []
+    for i in range(number_replicas):
+        dcd_file_list.append(f"{data_path}/replica_{i+1}.dcd")
+        
+    # Set path to native structure file:    
+    native_structure_file=f"{structures_path}/medoid_0.dcd"
+
+    # Tolerance for current trajectory distances:
+    native_contact_tol = 1.5    
+    
+    # Determine native contacts:
+    native_contact_list, native_contact_distances, opt_seq_spacing = get_helix_contacts(
+        cgmodel,
+        native_structure_file,
+        backbone_type_name='bb',
+    )
+    
+    full_T_list, Q_values, Q_uncertainty, sigmoid_results_boot = bootstrap_native_contacts_expectation(
+        cgmodel,
+        dcd_file_list,
+        native_contact_list,
+        native_contact_distances,
+        output_data=output_data,
+        frame_begin=100,
+        sample_spacing=20,
+        native_contact_tol=1.2,
+        num_intermediate_states=1,
+        n_trial_boot=10,
+        conf_percent='sigma',
+        plotfile=f'{output_directory}/native_contacts_boot_sym.pdf',
+        homopolymer_sym=True,
+        )
+        
+    assert os.path.isfile(f'{output_directory}/native_contacts_boot_sym.pdf')          
     
     
 def test_optimize_Q_helix_tol_dcd(tmpdir):

--- a/cg_openmm/tests/test_thermo.py
+++ b/cg_openmm/tests/test_thermo.py
@@ -171,7 +171,7 @@ def test_partial_heat_capacity_2state(tmpdir):
     array_folded_states = np.multiply((Q>=Q_folded),1)
     
     (Cv_partial, dCv_partial, temperature_list, \
-    FWHM_partial, Tm_partial, Cv_height_partial, U_expect_confs) = get_partial_heat_capacities(
+    FWHM_partial, Tm_partial, Cv_height_partial, U_expect_confs, N_eff_partial) = get_partial_heat_capacities(
         array_folded_states=array_folded_states,
         frame_begin=frame_begin,
         sample_spacing=1,
@@ -186,7 +186,7 @@ def test_partial_heat_capacity_2state(tmpdir):
     
     # Check data types of all output:
     for varname in [
-        'Cv_partial','FWHM_partial','Tm_partial','Cv_height_partial','U_expect_confs'
+        'Cv_partial','FWHM_partial','Tm_partial','Cv_height_partial','U_expect_confs','N_eff_partial',
         ]:
         
         assert eval(f'type({varname})') == dict
@@ -255,7 +255,7 @@ def test_bootstrap_partial_heat_capacity_2state_sigma(tmpdir):
     
     (T_list, Cv_values, Cv_uncertainty, Tm_value, Tm_uncertainty, \
     Cv_height_value, Cv_height_uncertainty, FWHM_value, FWHM_uncertainty, \
-    U_expect_values, U_expect_uncertainty) = bootstrap_partial_heat_capacities(
+    U_expect_values, U_expect_uncertainty, N_eff_values) = bootstrap_partial_heat_capacities(
         array_folded_states=array_folded_states,
         frame_begin=frame_begin,
         sample_spacing=1,
@@ -273,7 +273,8 @@ def test_bootstrap_partial_heat_capacity_2state_sigma(tmpdir):
     # Check data types of all output:
     for varname in ['Cv_values','Cv_uncertainty',
         'Tm_value','Tm_uncertainty','Cv_height_value','Cv_height_uncertainty',
-        'FWHM_value','FWHM_uncertainty','U_expect_values','U_expect_uncertainty'
+        'FWHM_value','FWHM_uncertainty','U_expect_values','U_expect_uncertainty',
+        'N_eff_values',
         ]:
         
         assert eval(f'type({varname})') == dict
@@ -342,7 +343,7 @@ def test_bootstrap_partial_heat_capacity_2state_conf(tmpdir):
     
     (T_list, Cv_values, Cv_uncertainty, Tm_value, Tm_uncertainty, \
     Cv_height_value, Cv_height_uncertainty, FWHM_value, FWHM_uncertainty, \
-    U_expect_values, U_expect_uncertainty) = bootstrap_partial_heat_capacities(
+    U_expect_values, U_expect_uncertainty, N_eff_values) = bootstrap_partial_heat_capacities(
         array_folded_states=array_folded_states,
         frame_begin=frame_begin,
         sample_spacing=2,
@@ -360,7 +361,8 @@ def test_bootstrap_partial_heat_capacity_2state_conf(tmpdir):
     # Check data types of all output:
     for varname in ['Cv_values','Cv_uncertainty',
         'Tm_value','Tm_uncertainty','Cv_height_value','Cv_height_uncertainty',
-        'FWHM_value','FWHM_uncertainty','U_expect_values','U_expect_uncertainty'
+        'FWHM_value','FWHM_uncertainty','U_expect_values','U_expect_uncertainty',
+        'N_eff_values',
         ]:
         
         assert eval(f'type({varname})') == dict


### PR DESCRIPTION
## Description
Some assorted fixes and updates:
1. Applies the conformational state decomposition for native contact expectations. This is done in a similar way as the 'partial' heat capacity contributions by manually summing the relevant MBAR weights. This is intended for systems with more than 2 configurational states, where we want the Q vs T expectation curves within each state.
2. Compute the number of effective samples for the configurational state partial heat capacities - these weights would be the same for the configurational state native contact expectations, so don't need to also compute there.
3. Fixes a bug in the native contacts end-to-end symmetry check, which occurred for the case of a linear homopolymer with 2 identical backbone beads in 1 residue.
4. New energy decomposition function - read in cgmodel and coordinate file, and return OpenMM total energy and contributions from bonds, angles, torsions, nonbonded force groups. 

## Todos
  - [ ] Tests for configurational state native contact expectations
  - [ ] Make the end-to-end symmetry check for native contacts more robust
  - [ ] Tests for energy decomposition
  - [ ] Fix import statement issues with OpenMM 7.6/7.7

## Status
- [ ] Ready to go