### PR TITLE
Helix geometry modeling for 2 and 3 sidechain models

### DIFF
--- a/cg_openmm/tests/test_helices.py
+++ b/cg_openmm/tests/test_helices.py
@@ -214,6 +214,54 @@ def test_optimize_helix_LJ_parameters_unconstrained(tmpdir):
     pdb_loaded = md.load(pdbfile)
     assert pdb_loaded.n_atoms == 24      
     
+    
+def test_optimize_helix_LJ_parameters_unconstrained_diff(tmpdir):
+    """
+    Test the LJ helix nonbonded parameter optimization function
+    (1sc, optimize sigmas with specified radius, pitch, no bond constraints,
+    energy difference objective function)
+    """
+    
+    # Helical parameters:
+    radius = 1.5 * unit.angstrom
+    pitch = 1.5 * unit.angstrom
+
+    # Number of backbone particles:
+    n_particle_bb = 12 
+    
+    output_directory = tmpdir.mkdir("output")
+    pdbfile = f"{output_directory}/helix_opt_LJ_openmm_unconstrained_test.pdb"
+    plotfile = f"{output_directory}/helix_opt_LJ_openmm_unconstrained_test.pdf"
+
+    opt_solution, geometry = optimize_helix_LJ_parameters(
+        radius, pitch, n_particle_bb,
+        bond_dist_bb=None, bond_dist_sc=None,
+        pdbfile=pdbfile, plotfile=plotfile,
+        DE_popsize=20, optimize_diff=True)
+               
+    assert os.path.isfile(pdbfile)
+    assert os.path.isfile(plotfile)
+    
+    # Check that the radius and pitch are satisfied:
+    radius_out = geometry['helical_radius']
+    pitch_out = geometry['pitch']
+    
+    assert_almost_equal(
+        radius.value_in_unit(unit.angstrom),
+        radius_out.value_in_unit(unit.angstrom),
+        decimal=6
+    )
+    
+    assert_almost_equal(
+        pitch.value_in_unit(unit.angstrom),
+        pitch_out.value_in_unit(unit.angstrom),
+        decimal=6
+    )
+    
+    # Check that we can load the pdb file
+    pdb_loaded = md.load(pdbfile)
+    assert pdb_loaded.n_atoms == 24          
+    
 
 def test_optimize_helix_LJ_parameters_constrained(tmpdir):
     """
@@ -280,6 +328,74 @@ def test_optimize_helix_LJ_parameters_constrained(tmpdir):
     # Check that we can load the pdb file
     pdb_loaded = md.load(pdbfile)
     assert pdb_loaded.n_atoms == 24    
+    
+    
+def test_optimize_helix_LJ_parameters_constrained_diff(tmpdir):
+    """
+    Test the LJ helix nonbonded parameter optimization function
+    (1sc, optimize sigmas with specified radius, pitch, fixed bond lengths,
+    energy difference objective function)
+    """
+    
+    # Helical parameters:
+    radius = 1.5 * unit.angstrom
+    pitch = 1.5 * unit.angstrom
+
+    # Number of backbone particles:
+    n_particle_bb = 12
+
+    # Bond constraints (equilibrium values)
+    bond_dist_bb = 1.10 * unit.angstrom
+    bond_dist_sc = 1.20 * unit.angstrom    
+    
+    output_directory = tmpdir.mkdir("output")
+    pdbfile = f"{output_directory}/helix_opt_LJ_openmm_constrained_test.pdb"
+    plotfile = f"{output_directory}/helix_opt_LJ_openmm_constrained_test.pdf"
+
+    opt_solution, geometry = optimize_helix_LJ_parameters(
+        radius, pitch, n_particle_bb,
+        bond_dist_bb=bond_dist_bb, bond_dist_sc=bond_dist_sc,
+        pdbfile=pdbfile, plotfile=plotfile,
+        DE_popsize=20, optimize_diff=True)
+
+    assert os.path.isfile(pdbfile)
+    assert os.path.isfile(plotfile)
+    
+    # Check that the bond constraints are satisfied:
+    bond_dist_bb_out = geometry['bb_bb_distance']
+    bond_dist_sc_out = geometry['bb_sc_distance']
+    
+    assert_almost_equal(
+        bond_dist_bb.value_in_unit(unit.angstrom),
+        bond_dist_bb_out.value_in_unit(unit.angstrom),
+        decimal=6
+    )
+    
+    assert_almost_equal(
+        bond_dist_sc.value_in_unit(unit.angstrom),
+        bond_dist_sc_out.value_in_unit(unit.angstrom),
+        decimal=6
+    )
+    
+    # Check that the radius and pitch are satisfied:
+    radius_out = geometry['helical_radius']
+    pitch_out = geometry['pitch']
+    
+    assert_almost_equal(
+        radius.value_in_unit(unit.angstrom),
+        radius_out.value_in_unit(unit.angstrom),
+        decimal=6
+    )
+    
+    assert_almost_equal(
+        pitch.value_in_unit(unit.angstrom),
+        pitch_out.value_in_unit(unit.angstrom),
+        decimal=6
+    )
+    
+    # Check that we can load the pdb file
+    pdb_loaded = md.load(pdbfile)
+    assert pdb_loaded.n_atoms == 24        
     
     
 def test_optimize_helix_LJ_parameters_2sc_equal(tmpdir):

--- a/cg_openmm/tests/test_helices.py
+++ b/cg_openmm/tests/test_helices.py
@@ -36,7 +36,7 @@ def test_optimize_helix_simple(tmpdir):
     plotfile = f"{output_directory}/LJ_helix_test.pdf"
     
     opt_solution, geometry = optimize_helix_simple(
-        n_particle_bb,sigma,epsilon,sidechain,
+        n_particle_bb, sigma, epsilon, sidechain,
         pdbfile=pdbfile, plotfile=plotfile,
         DE_popsize=10)
            
@@ -69,7 +69,7 @@ def test_optimize_helix_simple_sidechain(tmpdir):
     plotfile = f"{output_directory}/LJ_helix_sidechain_test.pdf"
     
     opt_solution, geometry = optimize_helix_simple(
-        n_particle_bb,sigma,epsilon,sidechain,
+        n_particle_bb, sigma, epsilon, sidechain,
         pdbfile=pdbfile, plotfile=plotfile,
         DE_popsize=10)
 
@@ -144,7 +144,7 @@ def test_optimize_helix_openmm_unconstrained_exclusions(tmpdir):
     opt_solution, geometry = optimize_helix_openmm_energy(
         n_particle_bb, sigma_bb, sigma_sc, epsilon_bb, epsilon_sc,
         pdbfile=pdbfile, plotfile=plotfile, bond_dist_bb=None, bond_dist_sc=None,
-        DE_popsize=20,exclusions=exclusions)
+        DE_popsize=20, exclusions=exclusions)
            
     assert os.path.isfile(pdbfile)
     assert os.path.isfile(plotfile)

--- a/cg_openmm/tests/test_helices.py
+++ b/cg_openmm/tests/test_helices.py
@@ -84,7 +84,7 @@ def test_optimize_helix_simple_sidechain(tmpdir):
 def test_optimize_helix_openmm_unconstrained(tmpdir):
     """
     Test the LJ helix geometry optimization function
-    (openmm energy with nonbonded exclusions, 1sc, unconstrained bond lengths)
+    (openmm energy with default [0,0,1] nonbonded exclusions, 1sc, unconstrained bond lengths)
     """
     
     # Particle LJ 12-6 parameters:
@@ -112,6 +112,46 @@ def test_optimize_helix_openmm_unconstrained(tmpdir):
     # Check that we can load the pdb file
     pdb_loaded = md.load(pdbfile)
     assert pdb_loaded.n_atoms == 24
+    
+    
+def test_optimize_helix_openmm_unconstrained_exclusions(tmpdir):
+    """
+    Test the LJ helix geometry optimization function
+    (openmm energy with non-default nonbonded exclusions, 1sc, unconstrained bond lengths)
+    """
+    
+    # Particle LJ 12-6 parameters:
+    sigma_bb = 1.0 * unit.angstrom
+    sigma_sc = 1.0 * unit.angstrom
+
+    epsilon_bb = 1.0 * unit.kilojoule_per_mole
+    epsilon_sc = 1.0 * unit.kilojoule_per_mole
+
+    # Number of backbone particles:
+    n_particle_bb = 12
+
+    # Set custom exclusion rules:
+    exclusions = {
+       "bb_bb_exclusions": [0,0,1],
+       "bb_sc_exclusions": [0,1,1],
+       "sc_sc_exclusions": [0,1,1],
+    }
+    
+    output_directory = tmpdir.mkdir("output")
+    pdbfile = f"{output_directory}/LJ_helix_openmm_unconstrained_test.pdb"
+    plotfile = f"{output_directory}/LJ_helix_openmm_unconstrained_test.pdf"
+    
+    opt_solution, geometry = optimize_helix_openmm_energy(
+        n_particle_bb, sigma_bb, sigma_sc, epsilon_bb, epsilon_sc,
+        pdbfile=pdbfile, plotfile=plotfile, bond_dist_bb=None, bond_dist_sc=None,
+        DE_popsize=20,exclusions=exclusions)
+           
+    assert os.path.isfile(pdbfile)
+    assert os.path.isfile(plotfile)
+    
+    # Check that we can load the pdb file
+    pdb_loaded = md.load(pdbfile)
+    assert pdb_loaded.n_atoms == 24    
     
 
 def test_optimize_helix_openmm_constrained(tmpdir):
@@ -168,10 +208,10 @@ def test_optimize_helix_openmm_constrained(tmpdir):
     assert pdb_loaded.n_atoms == 24    
     
     
-def test_optimize_helix_LJ_parameters_unconstrained(tmpdir):
+def test_optimize_helix_LJ_parameters_equal_bonds(tmpdir):
     """
     Test the LJ helix nonbonded parameter optimization function
-    (1sc, optimize sigmas with specified radius, pitch, no bond constraints)
+    (1sc, optimize sigmas with specified radius, pitch, equal bond lengths for bb-bb and bb-sc)
     """
     
     # Helical parameters:
@@ -182,14 +222,15 @@ def test_optimize_helix_LJ_parameters_unconstrained(tmpdir):
     n_particle_bb = 12 
     
     output_directory = tmpdir.mkdir("output")
-    pdbfile = f"{output_directory}/helix_opt_LJ_openmm_unconstrained_test.pdb"
-    plotfile = f"{output_directory}/helix_opt_LJ_openmm_unconstrained_test.pdf"
+    pdbfile = f"{output_directory}/helix_opt_LJ_openmm_equal_bonds_test.pdb"
+    plotfile = f"{output_directory}/helix_opt_LJ_openmm_equal_bonds_test.pdf"
 
     opt_solution, geometry = optimize_helix_LJ_parameters(
         radius, pitch, n_particle_bb,
         bond_dist_bb=None, bond_dist_sc=None,
+        equal_bonds=True, DE_popsize=20,
         pdbfile=pdbfile, plotfile=plotfile,
-        DE_popsize=20)
+        )
                
     assert os.path.isfile(pdbfile)
     assert os.path.isfile(plotfile)
@@ -207,6 +248,16 @@ def test_optimize_helix_LJ_parameters_unconstrained(tmpdir):
     assert_almost_equal(
         pitch.value_in_unit(unit.angstrom),
         pitch_out.value_in_unit(unit.angstrom),
+        decimal=6
+    )    
+    
+    # Check that equal bond length criteria is satisfied:
+    r_bb_out = geometry['bb_bb_distance']
+    r_bs_out = geometry['bb_sc_distance']
+    
+    assert_almost_equal(
+        r_bb_out.value_in_unit(unit.angstrom),
+        r_bs_out.value_in_unit(unit.angstrom),
         decimal=6
     )
     
@@ -215,11 +266,11 @@ def test_optimize_helix_LJ_parameters_unconstrained(tmpdir):
     assert pdb_loaded.n_atoms == 24      
     
     
-def test_optimize_helix_LJ_parameters_unconstrained_diff(tmpdir):
+def test_optimize_helix_LJ_parameters_unconstrained_bonds(tmpdir):
     """
     Test the LJ helix nonbonded parameter optimization function
-    (1sc, optimize sigmas with specified radius, pitch, no bond constraints,
-    energy difference objective function)
+    (1sc, optimize sigmas with specified radius, pitch, unconstrained independent bond lengths
+    for bb-bb and bb-sc)
     """
     
     # Helical parameters:
@@ -236,8 +287,9 @@ def test_optimize_helix_LJ_parameters_unconstrained_diff(tmpdir):
     opt_solution, geometry = optimize_helix_LJ_parameters(
         radius, pitch, n_particle_bb,
         bond_dist_bb=None, bond_dist_sc=None,
+        equal_bonds=False, DE_popsize=20,
         pdbfile=pdbfile, plotfile=plotfile,
-        DE_popsize=20, optimize_diff=True)
+        )
                
     assert os.path.isfile(pdbfile)
     assert os.path.isfile(plotfile)
@@ -260,10 +312,10 @@ def test_optimize_helix_LJ_parameters_unconstrained_diff(tmpdir):
     
     # Check that we can load the pdb file
     pdb_loaded = md.load(pdbfile)
-    assert pdb_loaded.n_atoms == 24          
+    assert pdb_loaded.n_atoms == 24               
     
 
-def test_optimize_helix_LJ_parameters_constrained(tmpdir):
+def test_optimize_helix_LJ_parameters_fixed_bonds(tmpdir):
     """
     Test the LJ helix nonbonded parameter optimization function
     (1sc, optimize sigmas with specified radius, pitch, fixed bond lengths)
@@ -281,14 +333,14 @@ def test_optimize_helix_LJ_parameters_constrained(tmpdir):
     bond_dist_sc = 1.20 * unit.angstrom    
     
     output_directory = tmpdir.mkdir("output")
-    pdbfile = f"{output_directory}/helix_opt_LJ_openmm_constrained_test.pdb"
-    plotfile = f"{output_directory}/helix_opt_LJ_openmm_constrained_test.pdf"
+    pdbfile = f"{output_directory}/helix_opt_LJ_openmm_fixed_bonds_test.pdb"
+    plotfile = f"{output_directory}/helix_opt_LJ_openmm_fixed_bonds_test.pdf"
 
     opt_solution, geometry = optimize_helix_LJ_parameters(
         radius, pitch, n_particle_bb,
         bond_dist_bb=bond_dist_bb, bond_dist_sc=bond_dist_sc,
         pdbfile=pdbfile, plotfile=plotfile,
-        DE_popsize=20)
+        equal_bonds=False, DE_popsize=20)
 
     assert os.path.isfile(pdbfile)
     assert os.path.isfile(plotfile)
@@ -330,10 +382,10 @@ def test_optimize_helix_LJ_parameters_constrained(tmpdir):
     assert pdb_loaded.n_atoms == 24    
     
     
-def test_optimize_helix_LJ_parameters_constrained_diff(tmpdir):
+def test_optimize_helix_LJ_parameters_energy_diff_equal_bonds(tmpdir):
     """
     Test the LJ helix nonbonded parameter optimization function
-    (1sc, optimize sigmas with specified radius, pitch, fixed bond lengths,
+    (1sc, optimize sigmas with specified radius, pitch, equal bonds,
     energy difference objective function)
     """
     
@@ -342,40 +394,23 @@ def test_optimize_helix_LJ_parameters_constrained_diff(tmpdir):
     pitch = 1.5 * unit.angstrom
 
     # Number of backbone particles:
-    n_particle_bb = 12
-
-    # Bond constraints (equilibrium values)
-    bond_dist_bb = 1.10 * unit.angstrom
-    bond_dist_sc = 1.20 * unit.angstrom    
+    n_particle_bb = 12 
     
     output_directory = tmpdir.mkdir("output")
-    pdbfile = f"{output_directory}/helix_opt_LJ_openmm_constrained_test.pdb"
-    plotfile = f"{output_directory}/helix_opt_LJ_openmm_constrained_test.pdf"
+    pdbfile = f"{output_directory}/helix_opt_LJ_openmm_energy_diff_equal_bonds_test.pdb"
+    plotfile = f"{output_directory}/helix_opt_LJ_openmm_energy_diff_equal_bonds_test.pdf"
 
-    opt_solution, geometry = optimize_helix_LJ_parameters(
+    geometry, opt_results_outer, opt_results_in = optimize_helix_LJ_parameters_energy_diff(
         radius, pitch, n_particle_bb,
-        bond_dist_bb=bond_dist_bb, bond_dist_sc=bond_dist_sc,
+        equal_bonds=True, brute_step_rad=0.2,
         pdbfile=pdbfile, plotfile=plotfile,
-        DE_popsize=20, optimize_diff=True)
-
-    assert os.path.isfile(pdbfile)
+        DE_popsize=20)
+               
+    extended_pdbfile = pdbfile[:-4]+'_ext.pdb'        
+               
     assert os.path.isfile(plotfile)
-    
-    # Check that the bond constraints are satisfied:
-    bond_dist_bb_out = geometry['bb_bb_distance']
-    bond_dist_sc_out = geometry['bb_sc_distance']
-    
-    assert_almost_equal(
-        bond_dist_bb.value_in_unit(unit.angstrom),
-        bond_dist_bb_out.value_in_unit(unit.angstrom),
-        decimal=6
-    )
-    
-    assert_almost_equal(
-        bond_dist_sc.value_in_unit(unit.angstrom),
-        bond_dist_sc_out.value_in_unit(unit.angstrom),
-        decimal=6
-    )
+    assert os.path.isfile(pdbfile)
+    assert os.path.isfile(extended_pdbfile)
     
     # Check that the radius and pitch are satisfied:
     radius_out = geometry['helical_radius']
@@ -393,9 +428,79 @@ def test_optimize_helix_LJ_parameters_constrained_diff(tmpdir):
         decimal=6
     )
     
-    # Check that we can load the pdb file
+    # Check that equal bond length criteria is satisfied:
+    r_bb_out = geometry['bb_bb_distance']
+    r_bs_out = geometry['bb_sc_distance']
+    
+    assert_almost_equal(
+        r_bb_out.value_in_unit(unit.angstrom),
+        r_bs_out.value_in_unit(unit.angstrom),
+        decimal=6
+    )
+    
+    # Check that we can load the helix pdb file
     pdb_loaded = md.load(pdbfile)
-    assert pdb_loaded.n_atoms == 24        
+    assert pdb_loaded.n_atoms == 24     
+
+    # Check that we can load the extended pdb file
+    pdb_loaded = md.load(extended_pdbfile)
+    assert pdb_loaded.n_atoms == 24
+    
+    
+def test_optimize_helix_LJ_parameters_energy_diff_unconstrained_bonds(tmpdir):
+    """
+    Test the LJ helix nonbonded parameter optimization function
+    (1sc, optimize sigmas with specified radius, pitch, independent
+    bb-bb and bb-sc bond lengths, energy difference objective function)
+    """
+    
+    # Helical parameters:
+    radius = 1.5 * unit.angstrom
+    pitch = 1.5 * unit.angstrom
+
+    # Number of backbone particles:
+    n_particle_bb = 12
+    
+    output_directory = tmpdir.mkdir("output")
+    pdbfile = f"{output_directory}/helix_opt_LJ_openmm_constrained_test.pdb"
+    plotfile = f"{output_directory}/helix_opt_LJ_openmm_constrained_test.pdf"
+
+    geometry, opt_results_outer, opt_results_in = optimize_helix_LJ_parameters_energy_diff(
+        radius, pitch, n_particle_bb,
+        equal_bonds=False, brute_step_rad=0.5,
+        brute_step_r_bs=0.5,
+        pdbfile=pdbfile, plotfile=plotfile,
+        DE_popsize=20)
+               
+    extended_pdbfile = pdbfile[:-4]+'_ext.pdb'        
+               
+    assert os.path.isfile(plotfile)
+    assert os.path.isfile(pdbfile)
+    assert os.path.isfile(extended_pdbfile)
+    
+    # Check that the radius and pitch are satisfied:
+    radius_out = geometry['helical_radius']
+    pitch_out = geometry['pitch']
+    
+    assert_almost_equal(
+        radius.value_in_unit(unit.angstrom),
+        radius_out.value_in_unit(unit.angstrom),
+        decimal=6
+    )
+    
+    assert_almost_equal(
+        pitch.value_in_unit(unit.angstrom),
+        pitch_out.value_in_unit(unit.angstrom),
+        decimal=6
+    )
+    
+    # Check that we can load the helix pdb file
+    pdb_loaded = md.load(pdbfile)
+    assert pdb_loaded.n_atoms == 24     
+
+    # Check that we can load the extended pdb file
+    pdb_loaded = md.load(extended_pdbfile)
+    assert pdb_loaded.n_atoms == 24     
     
     
 def test_optimize_helix_LJ_parameters_2sc_equal(tmpdir):
@@ -423,7 +528,73 @@ def test_optimize_helix_LJ_parameters_2sc_equal(tmpdir):
 
     opt_solution, geometry = optimize_helix_LJ_parameters_2sc(
         radius, pitch, n_particle_bb, sigma_bb, bond_dist_bb,
-        equal_sc=True, pdbfile=pdbfile, DE_popsize=20, plotfile=None)
+        equal_sc=True, pdbfile=pdbfile, DE_popsize=20)
+
+    assert os.path.isfile(pdbfile)
+    
+    # Check that the bond constraints are satisfied:
+    bond_dist_bb_out = geometry['bb_bb_distance']
+    
+    assert_almost_equal(
+        bond_dist_bb.value_in_unit(unit.angstrom),
+        bond_dist_bb_out.value_in_unit(unit.angstrom),
+        decimal=6
+    )
+
+    # Check that the radius and pitch are satisfied:
+    radius_out = geometry['helical_radius']
+    pitch_out = geometry['pitch']
+    
+    assert_almost_equal(
+        radius.value_in_unit(unit.angstrom),
+        radius_out.value_in_unit(unit.angstrom),
+        decimal=6
+    )
+    
+    assert_almost_equal(
+        pitch.value_in_unit(unit.angstrom),
+        pitch_out.value_in_unit(unit.angstrom),
+        decimal=6
+    )
+    
+    # Check that we can load the pdb file
+    pdb_loaded = md.load(pdbfile)
+    assert pdb_loaded.n_atoms == 36  
+
+
+def test_optimize_helix_LJ_parameters_2sc_equal_exclusions(tmpdir):
+    """
+    Test the LJ helix nonbonded parameter optimization function
+    (2sc model, equal sigma_sc: optimize sigma, bb-sc, sc-sc bond lengths
+    with specified radius, pitch, fixed bb-bb bond lengths and 
+    custom nonbonded exclusion rules)
+    """
+    
+    # Helical parameters:
+    radius = 1.5 * unit.angstrom
+    pitch = 1.5 * unit.angstrom
+
+    # Number of backbone particles:
+    n_particle_bb = 12
+
+    # Backbone sigma:
+    sigma_bb = 1.2 * unit.angstrom
+
+    # Bond constraints (equilibrium values)
+    bond_dist_bb = 1.10 * unit.angstrom  
+    
+    # Set custom exclusion rules:
+    exclusions = {
+       "default_exclusions": [1,1,1],
+    }    
+    
+    output_directory = tmpdir.mkdir("output")
+    pdbfile = f"{output_directory}/helix_opt_LJ_openmm_2sc_equal_test.pdb"
+
+    opt_solution, geometry = optimize_helix_LJ_parameters_2sc(
+        radius, pitch, n_particle_bb, sigma_bb, bond_dist_bb,
+        equal_sc=True, pdbfile=pdbfile, DE_popsize=20,
+        exclusions=exclusions)
 
     assert os.path.isfile(pdbfile)
     
@@ -482,7 +653,7 @@ def test_optimize_helix_LJ_parameters_2sc_nonequal(tmpdir):
 
     opt_solution, geometry = optimize_helix_LJ_parameters_2sc(
         radius, pitch, n_particle_bb, sigma_bb, bond_dist_bb,
-        equal_sc=False, pdbfile=pdbfile, DE_popsize=20, plotfile=None)
+        equal_sc=False, pdbfile=pdbfile, DE_popsize=20)
 
     assert os.path.isfile(pdbfile)
     
@@ -547,7 +718,7 @@ def test_optimize_helix_LJ_parameters_triangle_sc(tmpdir):
 
     opt_solution, geometry = optimize_helix_LJ_parameters_triangle_sidechain(
         radius, pitch, n_particle_bb, sigma_bb,
-        bond_dist_bb, pdbfile=pdbfile, DE_popsize=20, plotfile=None)
+        bond_dist_bb, pdbfile=pdbfile, DE_popsize=20)
 
     assert os.path.isfile(pdbfile)
     
@@ -589,4 +760,79 @@ def test_optimize_helix_LJ_parameters_triangle_sc(tmpdir):
     # Check that we can load the pdb file
     pdb_loaded = md.load(pdbfile)
     assert pdb_loaded.n_atoms == 48     
+        
+        
+def test_optimize_helix_LJ_parameters_triangle_sc_exclusions(tmpdir):
+    """
+    Test the LJ helix nonbonded parameter optimization function
+    (triangle 3sc model: optimize sigma, bb-sc bond length, triangle orientations type 1 and 2,
+    with specified radius, pitch, fixed bb-bb bond lengths and custom nonbonded exclusion rules)
+    """
+    
+    # Helical parameters:
+    radius = 1.5 * unit.angstrom
+    pitch = 1.5 * unit.angstrom
+
+    # Number of backbone particles:
+    n_particle_bb = 12
+
+    # Backbone sigma:
+    sigma_bb = 1.2 * unit.angstrom
+
+    # Bond constraints (equilibrium values)
+    bond_dist_bb = 1.10 * unit.angstrom  
+    
+    # Set custom exclusion rules:
+    exclusions = {
+       "default_exclusions": [1,1,1],
+    }        
+    
+    output_directory = tmpdir.mkdir("output")
+    pdbfile = f"{output_directory}/helix_opt_LJ_openmm_triangle_sc_test.pdb"
+
+    opt_solution, geometry = optimize_helix_LJ_parameters_triangle_sidechain(
+        radius, pitch, n_particle_bb, sigma_bb,
+        bond_dist_bb, pdbfile=pdbfile, DE_popsize=20,
+        exclusions=exclusions)
+
+    assert os.path.isfile(pdbfile)
+    
+    # Check that the bond constraints are satisfied:
+    bond_dist_bb_out = geometry['bb_bb_distance']
+    
+    assert_almost_equal(
+        bond_dist_bb.value_in_unit(unit.angstrom),
+        bond_dist_bb_out.value_in_unit(unit.angstrom),
+        decimal=6
+    )
+    
+    bond_dist_sc_out = geometry['sc_sc_distance']
+    sigma_sc_out = geometry['sigma_sc']
+    rmin_sc = 2**(1/6)*sigma_sc_out
+    
+    assert_almost_equal(
+        bond_dist_sc_out.value_in_unit(unit.angstrom),
+        rmin_sc.value_in_unit(unit.angstrom),
+        decimal=6
+    )
+
+    # Check that the radius and pitch are satisfied:
+    radius_out = geometry['helical_radius']
+    pitch_out = geometry['pitch']
+    
+    assert_almost_equal(
+        radius.value_in_unit(unit.angstrom),
+        radius_out.value_in_unit(unit.angstrom),
+        decimal=6
+    )
+    
+    assert_almost_equal(
+        pitch.value_in_unit(unit.angstrom),
+        pitch_out.value_in_unit(unit.angstrom),
+        decimal=6
+    )
+    
+    # Check that we can load the pdb file
+    pdb_loaded = md.load(pdbfile)
+    assert pdb_loaded.n_atoms == 48          
         

--- a/cg_openmm/utilities/helix_optimize_geometry.py
+++ b/cg_openmm/utilities/helix_optimize_geometry.py
@@ -366,6 +366,7 @@ def optimize_helix_openmm_energy(n_particle_bb, sigma_bb, sigma_sc, epsilon_bb, 
 def compute_LJ_helix_energy_simple(geo, sigma, epsilon, n_particle_bb, sidechain):
     """
     Internal function for computing energy of Lennard-Jones 12-6 helix
+    (no nonbonded exclusions nor bonded interactions)
     """
     
     # Particle spacing (radians)
@@ -411,6 +412,7 @@ def compute_LJ_helix_energy_simple(geo, sigma, epsilon, n_particle_bb, sidechain
 def compute_LJ_helix_openmm_energy(geo, simulation, bb_array, sc_array, n_particle_bb):
     """
     Internal function for computing openmm energy of Lennard-Jones 12-6 helix
+    (no constraints on bb-bb and bb-sc bond distances)
     """
     
     # Particle spacing (radians)
@@ -460,6 +462,7 @@ def compute_LJ_helix_openmm_energy_constrained(
     geo, simulation, bb_array, sc_array, n_particle_bb, bond_dist_bb, bond_dist_sc):
     """
     Internal function for computing openmm energy of Lennard-Jones 12-6 helix
+    (fixed bb-bb and bb-sc bond lengths)
     """
     
     # Helical radius (units of sigma)

--- a/cg_openmm/utilities/helix_optimize_geometry.py
+++ b/cg_openmm/utilities/helix_optimize_geometry.py
@@ -134,7 +134,7 @@ def optimize_helix_simple(n_particle_bb, sigma, epsilon, sidechain=True, DE_pops
    
 def optimize_helix_openmm_energy(n_particle_bb, sigma_bb, sigma_sc, epsilon_bb, epsilon_sc,
     bond_dist_bb=None, bond_dist_sc=None,DE_popsize=50,
-    pdbfile='LJ_helix_openmm_energy.pdb', plotfile='LJ_helix_openmm_energy.pdf'):
+    pdbfile='LJ_helix_openmm_energy.pdb', plotfile='LJ_helix_openmm_energy.pdf', exclusions={}):
     """
     Optimize backbone particle positions along a helix and helical radius, vertical rise,
     with equal spacing of particles. Assumes a 1-1 model with sidechain beads normal to helix.
@@ -169,6 +169,9 @@ def optimize_helix_openmm_energy(n_particle_bb, sigma_bb, sigma_sc, epsilon_bb, 
     :param plotfile: Path to pdf file for plotting the helical equations and particle positions (default='LJ_helix_openmm_energy.pdf')
     :type plotfile: str
     
+    :param exclusions: pass cg_openmm exclusion rules to the cgmodel (by default [0,0,1] is applied to all pair types)
+    :type exclusions: dict        
+    
     :returns:
       - opt_sol - Results from scipy.optimize (dict)
       - geometry - Dictionary containing key geometric parameters of the optimized helix
@@ -186,7 +189,7 @@ def optimize_helix_openmm_energy(n_particle_bb, sigma_bb, sigma_sc, epsilon_bb, 
     # t_delta is related to the specified bond distance - this must be computed at each iteration
     
     # Here we need to create a cgmodel
-    cgmodel = get_helix_cgmodel(sigma_bb,sigma_sc,epsilon_bb,epsilon_sc,n_particle_bb)
+    cgmodel = get_helix_cgmodel(sigma_bb,sigma_sc,epsilon_bb,epsilon_sc,n_particle_bb,exclusions)
     
     # Get particle type lists and bonded lists:
     (particle_type_list, bb_array, sc_array, bb_bond_list, sc_bond_list,

--- a/cg_openmm/utilities/helix_optimize_nonbonded.py
+++ b/cg_openmm/utilities/helix_optimize_nonbonded.py
@@ -940,9 +940,9 @@ def compute_helix_openmm_energy_vary_LJ_2sc_equal(geo, simulation,
     side_xyz1[:,1] = (1+r_bs/r)*xyz[:,1]
     side_xyz1[:,2] = xyz[:,2]
     
-    side_xyz2[:,0] = (1+2*r_bs/r)*xyz[:,0]
-    side_xyz2[:,1] = (1+2*r_bs/r)*xyz[:,1]
-    side_xyz2[:,2] = xyz[:,2]    
+    side_xyz2[:,0] = (1+(r_bs+r_ss)/r)*xyz[:,0]
+    side_xyz2[:,1] = (1+(r_bs+r_ss)/r)*xyz[:,1]
+    side_xyz2[:,2] = xyz[:,2]
     
     # Now, set the backbone and sidechain positions to the correct bead indices:
     positions = np.zeros((3*n_particle_bb,3))
@@ -1023,8 +1023,8 @@ def compute_helix_openmm_energy_vary_LJ_2sc_nonequal(geo, simulation,
     side_xyz1[:,1] = (1+r_bs/r)*xyz[:,1]
     side_xyz1[:,2] = xyz[:,2]
     
-    side_xyz2[:,0] = (1+2*r_bs/r)*xyz[:,0]
-    side_xyz2[:,1] = (1+2*r_bs/r)*xyz[:,1]
+    side_xyz2[:,0] = (1+(r_bs+r_ss)/r)*xyz[:,0]
+    side_xyz2[:,1] = (1+(r_bs+r_ss)/r)*xyz[:,1]
     side_xyz2[:,2] = xyz[:,2]    
     
     # Now, set the backbone and sidechain positions to the correct bead indices:

--- a/cg_openmm/utilities/helix_optimize_nonbonded.py
+++ b/cg_openmm/utilities/helix_optimize_nonbonded.py
@@ -191,8 +191,6 @@ def optimize_helix_LJ_parameters(radius, pitch, n_particle_bb,
             r_bs = bond_dist_sc
         else:
             # Use optimized bb-sc bond distance:
-            # Testing out inverted helix
-            # r_bs = -r_bs_opt
             r_bs = r_bs_opt
     
     side_xyz = np.zeros((n_particle_bb,3))
@@ -1079,10 +1077,6 @@ def optimize_helix_LJ_parameters_triangle_sidechain(radius, pitch, n_particle_bb
     dihedral_indices = np.array([[sbbs_torsion_list[0][0], sbbs_torsion_list[0][1], sbbs_torsion_list[0][2], sbbs_torsion_list[0][3]]])
     geometry['sc_bb_bb_sc_angle'] = (md.compute_dihedrals(traj,dihedral_indices)*unit.radians).in_units_of(unit.degrees)[0][0]
 
-    # # Plot helix:
-    # if plotfile is not None:
-        # plot_LJ_helix(r,c,t_par,r_eq_bb,r_eq_sc=r_eq_sc,plotfile=plotfile)
-    
     return opt_sol, geometry
 
 
@@ -1117,8 +1111,6 @@ def compute_helix_openmm_energy_vary_LJ(geo, simulation, bb_array, sc_array,
     
     if not equal_bonds:
         r_bs = geo[3] # Angstrom
-        # Testing out inverted helix:
-        # r_bs = -np.abs(geo[3])
     else:
         r_bs = r_bb
     

--- a/cg_openmm/utilities/helix_optimize_nonbonded.py
+++ b/cg_openmm/utilities/helix_optimize_nonbonded.py
@@ -386,9 +386,9 @@ def optimize_helix_LJ_parameters_2sc(radius, pitch, n_particle_bb, sigma_bb,
     side_xyz1[:,1] = (1+r_bs/r)*xyz[:,1]
     side_xyz1[:,2] = xyz[:,2]
     
-    side_xyz2[:,0] = (1+2*r_bs/r)*xyz[:,0]
-    side_xyz2[:,1] = (1+2*r_bs/r)*xyz[:,1]
-    side_xyz2[:,2] = xyz[:,2]    
+    side_xyz2[:,0] = (1+(r_bs+r_ss)/r)*xyz[:,0]
+    side_xyz2[:,1] = (1+(r_bs+r_ss)/r)*xyz[:,1]
+    side_xyz2[:,2] = xyz[:,2]      
     
     # Now, set the backbone and sidechain positions to the correct bead indices:
     positions = np.zeros((3*n_particle_bb,3))

--- a/cg_openmm/utilities/helix_optimize_nonbonded.py
+++ b/cg_openmm/utilities/helix_optimize_nonbonded.py
@@ -15,7 +15,7 @@ def optimize_helix_LJ_parameters(radius, pitch, n_particle_bb,
     bond_dist_bb=None, bond_dist_sc=None,DE_popsize=50,
     pdbfile='LJ_helix_openmm_energy.pdb', plotfile='LJ_helix_openmm_energy.pdf'):
     """
-    Optimize backbone and sidechain particle parameters along a helix with specified radius and
+    1sc model: Optimize backbone and sidechain particle parameters along a helix with specified radius and
     pitch, with equal spacing of backbone particles and sidechain beads normal to the helix.
     
     :param radius: fixed helical radius
@@ -236,9 +236,246 @@ def optimize_helix_LJ_parameters(radius, pitch, n_particle_bb,
     return opt_sol, geometry
 
 
+def optimize_helix_LJ_parameters_2sc(radius, pitch, n_particle_bb, sigma_bb,
+    bond_dist_bb, equal_sc=True, DE_popsize=200, pdbfile='LJ_helix_2sc_opt.pdb',
+    plotfile='LJ_helix_openmm_energy.pdf'):
+    """
+    With specified radius, pitch, backbone sigma, and backbone-backbone bond length, 
+    optimize the sidechain sigma and bb-sc, sc-sc bond lengths in a helix with
+    1 backbone bead and 2 sidechain beads extending normal to the backbone.
+    
+    :param radius: fixed helical radius
+    :type radius: Quantity
+    
+    :param pitch: fixed helical pitch (c*2*pi)
+    :type pitch: Quantity
+    
+    :param n_particle_bb: Number of backbone particles to model
+    :type n_particle_bb: int
+    
+    :param sigma_bb: LJ sigma parameter for backbone beads
+    :type sigma_bb: Quantity
+    
+    :param bond_dist_bb: bond distance for bb-bb bonds.
+    :type bond_dist_bb: Quantity
+
+    :param equal_sc: Option for keeping the sigma_sc of each sidechain bead the same. If False, each sigma_sc will be varied independently. (default=True)
+    :type equal_sc: bool
+    
+    :param DE_popsize: population size to use in SciPy differential_evolution solver (default=50)
+    :type DE_popsize: int
+
+    :param pdbfile: Path to pdb file for saving the helical structure (default='LJ_helix_openmm_energy.pdb')
+    :type pdbfile: str
+    
+    :returns:
+      - opt_sol - Results from scipy.optimize (dict)
+      - geometry - Dictionary containing key geometric parameters of the optimized helix
+    """
+    
+    r_unit = radius.unit
+    # Use angstrom for writing pdb file:
+    radius = radius.value_in_unit(unit.angstrom)
+    pitch = pitch.value_in_unit(unit.angstrom)
+    
+    r = radius
+    c = pitch/(2*np.pi) # Helical rise parameter
+    
+    # Here we need to create a cgmodel
+    
+    # Set initial epsilon parameters
+    epsilon_bb = 1.0 * unit.kilojoule_per_mole
+    epsilon_sc = 1.0 * unit.kilojoule_per_mole
+    
+    # Set initial sigma parameters
+    sigma_sc = 1.0 * unit.angstrom
+    
+    if equal_sc:
+        cgmodel = get_helix_cgmodel_2sc_equal(sigma_bb,sigma_sc,epsilon_bb,epsilon_sc,n_particle_bb)
+    else:
+        # Need to set 2 independent particle types for sc1, sc2
+        cgmodel = get_helix_cgmodel_2sc_nonequal(sigma_bb,sigma_sc,epsilon_bb,epsilon_sc,n_particle_bb)
+    
+    # Get particle type lists and bonded lists:
+    # (sc1 and sc2 have the same bonded type here)
+    (particle_type_list, bb_array, sc_array,
+    bb_bond_list, bs_bond_list, ss_bond_list,
+    bbb_angle_list, bbs_angle_list, bss_angle_list,
+    bbbb_torsion_list, bbbs_torsion_list, bbss_torsion_list,
+    sbbs_torsion_list)  = get_helix_particle_bonded_lists_2sc(cgmodel)
+    
+    # Set up Simulation object beforehand:
+    simulation_time_step = 5.0 * unit.femtosecond
+    friction = 0.0 / unit.picosecond
+    integrator = LangevinIntegrator(
+        0.0 * unit.kelvin, friction, simulation_time_step.in_units_of(unit.picosecond)
+    )
+    simulation = Simulation(cgmodel.topology, cgmodel.system, integrator)    
+    
+    bond_dist_bb = bond_dist_bb.value_in_unit(unit.angstrom)
+
+    params = (simulation, particle_type_list, r, c, n_particle_bb, bond_dist_bb)
+
+    if equal_sc:
+        #-----------------------#
+        # Equal sidechain sigma #
+        #-----------------------#
+        
+        # Set optimization bounds [r_bs, r_ss, sigma_sc]:
+        bounds = [(r/50,5*r),(r/50,5*r),(r/50,10*r)]
+        
+        opt_sol = differential_evolution(
+            compute_helix_openmm_energy_vary_LJ_2sc_equal,
+            bounds,
+            args=params,
+            polish=True,
+            popsize=DE_popsize,
+        )
+        
+        r_bs = opt_sol.x[0]
+        r_ss = opt_sol.x[1]
+        
+        sigma_sc1_opt = opt_sol.x[2]
+        sigma_sc2_opt = sigma_sc1_opt
+    
+    else:
+        #---------------------------#
+        # Non-equal sidechain sigma #
+        #---------------------------#
+        
+        # Set optimization bounds [r_bs, r_ss, sigma_sc1, sigma_sc2]:
+        bounds = [(r/50,5*r),(r/50,5*r),(r/50,10*r),(r/50,10*r)]
+        
+        opt_sol = differential_evolution(
+            compute_helix_openmm_energy_vary_LJ_2sc_nonequal,
+            bounds,
+            args=params,
+            polish=True,
+            popsize=DE_popsize,
+        )
+        
+        r_bs = opt_sol.x[0]
+        r_ss = opt_sol.x[1]
+        
+        sigma_sc1_opt = opt_sol.x[2]
+        sigma_sc2_opt = opt_sol.x[3]
+           
+    # Compute particle spacing based on bond constraints
+    t_delta_opt = get_t_from_bond_distance(r,c,bond_dist_bb)
+    if t_delta_opt < 0:
+        print(t_delta_opt)
+        t_delta_opt *= -1
+    
+    t_par = np.zeros(n_particle_bb)
+    for i in range(n_particle_bb):
+        t_par[i] = i*t_delta_opt  
+
+    # Equilibrium LJ distance (for visual representation)
+    r_eq_bb = sigma_bb.value_in_unit(unit.angstrom)*np.power(2,(1/6))
+    r_eq_sc1 = sigma_sc1_opt*np.power(2,(1/6))
+    r_eq_sc2 = sigma_sc2_opt*np.power(2,(1/6))
+    
+    # Get particle positions:
+    xyz = get_helix_coordinates(r,c,t_par)
+
+    # Place sidechain particles normal to helix:
+    side_xyz1 = np.zeros((n_particle_bb,3))
+    side_xyz2 = np.zeros_like(side_xyz1)
+    
+    side_xyz1[:,0] = (1+r_bs/r)*xyz[:,0]
+    side_xyz1[:,1] = (1+r_bs/r)*xyz[:,1]
+    side_xyz1[:,2] = xyz[:,2]
+    
+    side_xyz2[:,0] = (1+2*r_bs/r)*xyz[:,0]
+    side_xyz2[:,1] = (1+2*r_bs/r)*xyz[:,1]
+    side_xyz2[:,2] = xyz[:,2]    
+    
+    # Now, set the backbone and sidechain positions to the correct bead indices:
+    positions = np.zeros((3*n_particle_bb,3))
+    
+    j = -1
+    for i in range(n_particle_bb):
+        j += 1
+        positions[j] = xyz[i]
+        
+        j += 1
+        positions[j] = side_xyz1[i]
+        
+        j += 1
+        positions[j] = side_xyz2[i]
+            
+    positions *= unit.angstrom
+    
+    # Write pdb file
+    cgmodel.positions = positions
+    write_pdbfile_without_topology(cgmodel, pdbfile)    
+    
+    # Also write dcd file (better precision)
+    dcdfile = pdbfile[:-3]+'dcd'
+    dcdtraj = md.Trajectory(
+        xyz=positions,
+        topology=md.Topology.from_openmm(cgmodel.topology),
+    )
+    md.Trajectory.save_dcd(dcdtraj,dcdfile)    
+    
+    # Store key geometric parameters
+    geometry = {}
+    
+    geometry['sigma_bb'] = sigma_bb.in_units_of(r_unit)
+    geometry['sigma_sc1'] = (sigma_sc1_opt*unit.angstrom).in_units_of(r_unit)
+    geometry['sigma_sc2'] = (sigma_sc2_opt*unit.angstrom).in_units_of(r_unit) 
+    
+    # Add back units:
+    geometry['helical_radius'] = r * r_unit
+    geometry['particle_spacing'] = t_delta_opt * unit.radian
+    geometry['pitch'] = (2*np.pi*c) * r_unit
+        
+    # Load dcd file into mdtraj
+    traj = md.load(dcdfile,top=md.Topology.from_openmm(cgmodel.topology))
+    
+    # Get bb-bb bond distance
+    geometry['bb_bb_distance'] = (dist_unitless(positions[bb_bond_list[0][0],:],positions[bb_bond_list[0][1],:]) * unit.angstrom).in_units_of(r_unit)
+    geometry['bb_sc_distance'] = (dist_unitless(positions[bs_bond_list[0][0],:],positions[bs_bond_list[0][1],:]) * unit.angstrom).in_units_of(r_unit)
+    geometry['sc_sc_distance'] = (dist_unitless(positions[ss_bond_list[0][0],:],positions[ss_bond_list[0][1],:]) * unit.angstrom).in_units_of(r_unit) 
+    
+    # Get bb-bb-bb angle
+    angle_indices = np.array([[bbb_angle_list[0][0], bbb_angle_list[0][1], bbb_angle_list[0][2]]])
+    geometry['bb_bb_bb_angle'] = (md.compute_angles(traj,angle_indices)*unit.radians).in_units_of(unit.degrees)[0][0]
+    
+    # Get bb-bb-sc angle
+    angle_indices = np.array([[bbs_angle_list[0][0], bbs_angle_list[0][1], bbs_angle_list[0][2]]])
+    geometry['bb_bb_sc_angle'] = (md.compute_angles(traj,angle_indices)*unit.radians).in_units_of(unit.degrees)[0][0]
+    
+    # Get bb-sc-sc angle
+    angle_indices = np.array([[bss_angle_list[0][0], bss_angle_list[0][1], bss_angle_list[0][2]]])
+    geometry['bb_sc_sc_angle'] = (md.compute_angles(traj,angle_indices)*unit.radians).in_units_of(unit.degrees)[0][0]         
+    
+    # Get bb-bb-bb-bb torsion
+    dihedral_indices = np.array([[bbbb_torsion_list[0][0], bbbb_torsion_list[0][1], bbbb_torsion_list[0][2], bbbb_torsion_list[0][3]]])
+    geometry['bb_bb_bb_bb_angle'] = (md.compute_dihedrals(traj,dihedral_indices)*unit.radians).in_units_of(unit.degrees)[0][0]
+    
+    # Get bb-bb-bb-sc torsion
+    dihedral_indices = np.array([[bbbs_torsion_list[0][0], bbbs_torsion_list[0][1], bbbs_torsion_list[0][2], bbbs_torsion_list[0][3]]])
+    geometry['bb_bb_bb_sc_angle'] = (md.compute_dihedrals(traj,dihedral_indices)*unit.radians).in_units_of(unit.degrees)[0][0]     
+    
+    # Get bb-bb-sc-sc torsion
+    dihedral_indices = np.array([[bbss_torsion_list[0][0], bbss_torsion_list[0][1], bbss_torsion_list[0][2], bbss_torsion_list[0][3]]])
+    geometry['bb_bb_sc_sc_angle'] = (md.compute_dihedrals(traj,dihedral_indices)*unit.radians).in_units_of(unit.degrees)[0][0]    
+
+    # Get sc-bb-bb-sc torsion
+    dihedral_indices = np.array([[sbbs_torsion_list[0][0], sbbs_torsion_list[0][1], sbbs_torsion_list[0][2], sbbs_torsion_list[0][3]]])
+    geometry['sc_bb_bb_sc_angle'] = (md.compute_dihedrals(traj,dihedral_indices)*unit.radians).in_units_of(unit.degrees)[0][0]
+
+    # # Plot helix:
+    # if plotfile is not None:
+        # plot_LJ_helix(r,c,t_par,r_eq_bb,r_eq_sc=r_eq_sc,plotfile=plotfile)
+    
+    return opt_sol, geometry
+
+
 def optimize_helix_LJ_parameters_triangle_sidechain(radius, pitch, n_particle_bb, sigma_bb,
     bond_dist_bb, DE_popsize=200, pdbfile='LJ_helix_openmm_energy.pdb',
-    plotfile='LJ_helix_openmm_energy.pdf'):
+    plotfile=None):
     """
     With specified radius, pitch, backbone sigma, and backbone-backbone bond length, 
     optimize the sidechain sigma and backbone-sidechain bond length in a helix with
@@ -261,9 +498,6 @@ def optimize_helix_LJ_parameters_triangle_sidechain(radius, pitch, n_particle_bb
     
     :param bond_dist_bb: bond distance for bb-bb bonds.
     :type bond_dist_bb: Quantity
-
-    :param constrain_bb_sc_bond_distance: Option to constrain bb-sc bond distance to the same as sc-sc bond distance. If False, bb_sc will be optimized.
-    :type constrain_bb_sc_bond_distance: bool
 
     :param DE_popsize: population size to use in SciPy differential_evolution solver (default=50)
     :type DE_popsize: int
@@ -629,7 +863,7 @@ def compute_helix_openmm_energy_vary_LJ(geo, simulation, bb_array, sc_array,
     U_helix = potential_energy.value_in_unit(unit.kilojoules_per_mole)
         
     return U_helix    
-    
+
 
 def rotate_coordinates_z(xyz,theta):
     """
@@ -663,6 +897,176 @@ def rotate_coordinates_x(xyz,theta):
     xyz_rot = np.matmul(R_mat, xyz)
     
     return xyz_rot    
+    
+ 
+def compute_helix_openmm_energy_vary_LJ_2sc_equal(geo, simulation,
+    particle_type_list, r, c, n_particle_bb, bond_dist_bb):
+    """
+    Internal function for computing openmm energy of Lennard-Jones 12-6 helix
+    (2sc model, equal sigma_sc for sidechain beads)
+    """
+
+    # Backbone-sidechain bond length:
+    r_bs = geo[0]
+    
+    # Sidechain-sidechain bond length:
+    r_ss = geo[1]  
+    
+    # Backbone sigma parameter:
+    
+    
+    # Sidechain sigma parameter
+    sigma_sc = geo[2] * unit.angstrom
+    
+    # Particle spacing (radians)
+    t_delta = get_t_from_bond_distance(r,c,bond_dist_bb)
+    
+    t1 = np.zeros(n_particle_bb)
+    for i in range(n_particle_bb):
+        t1[i] = i*t_delta
+        
+    xyz = get_helix_coordinates(r,c,t1)
+        
+    # If the bonds, angles, and backbone torsions are at their equilibrium positions,
+    # then we don't need to update any parameters in the simulation object. Just
+    # the nonbonded energies need to be evaluated. In the cgmodel, all force constants
+    # are zero.
+        
+    # Place sidechain particles normal to helix:
+    side_xyz1 = np.zeros((n_particle_bb,3))
+    side_xyz2 = np.zeros_like(side_xyz1)
+    
+    side_xyz1[:,0] = (1+r_bs/r)*xyz[:,0]
+    side_xyz1[:,1] = (1+r_bs/r)*xyz[:,1]
+    side_xyz1[:,2] = xyz[:,2]
+    
+    side_xyz2[:,0] = (1+2*r_bs/r)*xyz[:,0]
+    side_xyz2[:,1] = (1+2*r_bs/r)*xyz[:,1]
+    side_xyz2[:,2] = xyz[:,2]    
+    
+    # Now, set the backbone and sidechain positions to the correct bead indices:
+    positions = np.zeros((3*n_particle_bb,3))
+    
+    j = -1
+    for i in range(n_particle_bb):
+        j += 1
+        positions[j] = xyz[i]
+        
+        j += 1
+        positions[j] = side_xyz1[i]
+        
+        j += 1
+        positions[j] = side_xyz2[i]
+            
+    positions *= unit.angstrom
+    
+    # Update the nonbonded parameters:
+    for force_index, force in enumerate(simulation.system.getForces()):
+        force_name = force.__class__.__name__
+        if force_name == 'NonbondedForce':
+            for particle_index in range(len(particle_type_list)):
+                (q,sigma_old,eps) = force.getParticleParameters(particle_index)
+                
+                # Only need to change the sigma values here:
+                if particle_type_list[particle_index] == 'bb':
+                    # This is constant and set when creating the cgmodel
+                    pass
+                else:
+                    force.setParticleParameters(particle_index,q,sigma_sc,eps)
+                force.updateParametersInContext(simulation.context)
+            
+    # Update the positions:        
+    simulation.context.setPositions(positions)
+    potential_energy = simulation.context.getState(getEnergy=True).getPotentialEnergy()
+    
+    U_helix = potential_energy.value_in_unit(unit.kilojoules_per_mole)
+        
+    return U_helix     
+    
+    
+def compute_helix_openmm_energy_vary_LJ_2sc_nonequal(geo, simulation,
+    particle_type_list, r, c, n_particle_bb, bond_dist_bb):
+    """
+    Internal function for computing openmm energy of Lennard-Jones 12-6 helix
+    (2sc model, different sigma_sc for sidechain beads)
+    """
+
+    # Backbone-sidechain bond length:
+    r_bs = geo[0]
+    
+    # Sidechain-sidechain bond length:
+    r_ss = geo[1]  
+    
+    # Sidechain sigma parameters
+    sigma_sc1 = geo[2] * unit.angstrom
+    sigma_sc2 = geo[3] * unit.angstrom
+    
+    # Particle spacing (radians)
+    t_delta = get_t_from_bond_distance(r,c,bond_dist_bb)
+    
+    t1 = np.zeros(n_particle_bb)
+    for i in range(n_particle_bb):
+        t1[i] = i*t_delta
+        
+    xyz = get_helix_coordinates(r,c,t1)
+        
+    # If the bonds, angles, and backbone torsions are at their equilibrium positions,
+    # then we don't need to update any parameters in the simulation object. Just
+    # the nonbonded energies need to be evaluated. In the cgmodel, all force constants
+    # are zero.
+        
+    # Place sidechain particles normal to helix:
+    side_xyz1 = np.zeros((n_particle_bb,3))
+    side_xyz2 = np.zeros_like(side_xyz1)
+    
+    side_xyz1[:,0] = (1+r_bs/r)*xyz[:,0]
+    side_xyz1[:,1] = (1+r_bs/r)*xyz[:,1]
+    side_xyz1[:,2] = xyz[:,2]
+    
+    side_xyz2[:,0] = (1+2*r_bs/r)*xyz[:,0]
+    side_xyz2[:,1] = (1+2*r_bs/r)*xyz[:,1]
+    side_xyz2[:,2] = xyz[:,2]    
+    
+    # Now, set the backbone and sidechain positions to the correct bead indices:
+    positions = np.zeros((3*n_particle_bb,3))
+    
+    j = -1
+    for i in range(n_particle_bb):
+        j += 1
+        positions[j] = xyz[i]
+        
+        j += 1
+        positions[j] = side_xyz1[i]
+        
+        j += 1
+        positions[j] = side_xyz2[i]
+            
+    positions *= unit.angstrom
+    
+    # Update the nonbonded parameters:
+    for force_index, force in enumerate(simulation.system.getForces()):
+        force_name = force.__class__.__name__
+        if force_name == 'NonbondedForce':
+            for particle_index in range(len(particle_type_list)):
+                (q,sigma_old,eps) = force.getParticleParameters(particle_index)
+                
+                # Only need to change the sigma values here:
+                if particle_type_list[particle_index] == 'bb':
+                    # This is constant and set when creating the cgmodel
+                    pass
+                elif particle_type_list[particle_index] == 'sc1':
+                    force.setParticleParameters(particle_index,q,sigma_sc1,eps)
+                elif particle_type_list[particle_index] == 'sc2':
+                    force.setParticleParameters(particle_index,q,sigma_sc2,eps)    
+                force.updateParametersInContext(simulation.context)
+            
+    # Update the positions:        
+    simulation.context.setPositions(positions)
+    potential_energy = simulation.context.getState(getEnergy=True).getPotentialEnergy()
+    
+    U_helix = potential_energy.value_in_unit(unit.kilojoules_per_mole)
+        
+    return U_helix        
     
     
 def compute_helix_openmm_energy_vary_LJ_constrained(
@@ -887,11 +1291,13 @@ def compute_helix_openmm_energy_vary_LJ_triangle(
         force_name = force.__class__.__name__
         if force_name == 'NonbondedForce':
             for particle_index in range(len(particle_type_list)):
-                (q,sigma_old,eps) = force.getParticleParameters(particle_index)
-                
+            
                 # Only need to change the sigma_sc values here:
-                force.setParticleParameters(particle_index,q,sigma_sc,eps)
-                force.updateParametersInContext(simulation.context)
+                if particle_type_list[particle_index] == 'sc':
+                    (q,sigma_old,eps) = force.getParticleParameters(particle_index)
+                    
+                    force.setParticleParameters(particle_index,q,sigma_sc,eps)
+                    force.updateParametersInContext(simulation.context)
             
     # Update the positions:        
     simulation.context.setPositions(positions)

--- a/cg_openmm/utilities/helix_optimize_nonbonded.py
+++ b/cg_openmm/utilities/helix_optimize_nonbonded.py
@@ -94,7 +94,8 @@ def optimize_helix_LJ_parameters(radius, pitch, n_particle_bb,
         params = (simulation, bb_array, sc_array, particle_type_list, r, c, n_particle_bb)
     
         # Set optimization bounds [t, sigma_bb, sigma_sc]:
-        bounds = [(0.01,np.pi),(r/50,15*r),(r/50,15*r)]
+        # Use a minimium of 3 residues/turn
+        bounds = [(0.01,2*np.pi/3),(r/50,15*r),(r/50,15*r)]
 
         opt_sol = differential_evolution(
             compute_helix_openmm_energy_vary_LJ,
@@ -155,27 +156,27 @@ def optimize_helix_LJ_parameters(radius, pitch, n_particle_bb,
     r_eq_sc = sigma_sc_opt*np.power(2,(1/6))
     
     # Get particle positions:
-    xyz_par = get_helix_coordinates(r,c,t_par)
+    xyz = get_helix_coordinates(r,c,t_par)
     
     # Place sidechain particles normal to helix
     if bond_dist_sc == None:
         # Use optimized bond length from first two backbone beads:
-        r_bs = dist_unitless(xyz_par[0,:],xyz_par[1,:])
+        r_bs = dist_unitless(xyz[0,:],xyz[1,:])
     else:
         # Use specified bb-sc bond distance:
         r_bs = bond_dist_sc
     
     side_xyz = np.zeros((n_particle_bb,3))
 
-    side_xyz[:,0] = (1+r_bs/r)*xyz_par[:,0]
-    side_xyz[:,1] = (1+r_bs/r)*xyz_par[:,1]
-    side_xyz[:,2] = xyz_par[:,2]
+    side_xyz[:,0] = (1+r_bs/r)*xyz[:,0]
+    side_xyz[:,1] = (1+r_bs/r)*xyz[:,1]
+    side_xyz[:,2] = xyz[:,2]
     
     # Now, set the backbone and sidechain positions to the correct bead indices:
     positions = np.zeros((2*n_particle_bb,3))
     
     # This assumes that the backbone and sidechain beads are ordered from end-to-end
-    positions[bb_array] = xyz_par
+    positions[bb_array] = xyz
     positions[sc_array] = side_xyz
     
     # Write pdb file
@@ -234,7 +235,336 @@ def optimize_helix_LJ_parameters(radius, pitch, n_particle_bb,
     
     return opt_sol, geometry
 
+
+def optimize_helix_LJ_parameters_triangle_sidechain(radius, pitch, n_particle_bb, sigma_bb,
+    bond_dist_bb, DE_popsize=200, pdbfile='LJ_helix_openmm_energy.pdb',
+    plotfile='LJ_helix_openmm_energy.pdf'):
+    """
+    With specified radius, pitch, backbone sigma, and backbone-backbone bond length, 
+    optimize the sidechain sigma and backbone-sidechain bond length in a helix with
+    1 backbone bead and 3 sidechain beads in an equilateral triangle whose center is
+    normal to the backbone bead, and plane of the triangle runs parallel to the helical axis.
+    For now, the orientations of the triangles are alternating between 2 sidechain beads at the top,
+    and 2 sidechain beads at the bottom.
     
+    :param radius: fixed helical radius
+    :type radius: Quantity
+    
+    :param pitch: fixed helical pitch (c*2*pi)
+    :type pitch: Quantity
+    
+    :param n_particle_bb: Number of backbone particles to model
+    :type n_particle_bb: int
+    
+    :param sigma_bb: LJ sigma parameter for backbone beads
+    :type sigma_bb: Quantity
+    
+    :param bond_dist_bb: bond distance for bb-bb bonds.
+    :type bond_dist_bb: Quantity
+
+    :param constrain_bb_sc_bond_distance: Option to constrain bb-sc bond distance to the same as sc-sc bond distance. If False, bb_sc will be optimized.
+    :type constrain_bb_sc_bond_distance: bool
+
+    :param DE_popsize: population size to use in SciPy differential_evolution solver (default=50)
+    :type DE_popsize: int
+
+    :param pdbfile: Path to pdb file for saving the helical structure (default='LJ_helix_openmm_energy.pdb')
+    :type pdbfile: str
+    
+    :returns:
+      - opt_sol - Results from scipy.optimize (dict)
+      - geometry - Dictionary containing key geometric parameters of the optimized helix
+    """
+    
+    r_unit = radius.unit
+    # Use angstrom for writing pdb file:
+    radius = radius.value_in_unit(unit.angstrom)
+    pitch = pitch.value_in_unit(unit.angstrom)
+    
+    r = radius
+    c = pitch/(2*np.pi) # Helical rise parameter
+    
+    # Here we need to create a cgmodel
+    
+    # Set initial epsilon parameters
+    epsilon_bb = 1.0 * unit.kilojoule_per_mole
+    epsilon_sc = 1.0 * unit.kilojoule_per_mole
+    
+    # Set initial sigma parameters
+    sigma_sc = 1.0 * unit.angstrom
+    
+    cgmodel = get_helix_cgmodel_triangle(sigma_bb,sigma_sc,epsilon_bb,epsilon_sc,n_particle_bb)
+    
+    # Get particle type lists and bonded lists:
+    (particle_type_list, bb_array, sc_array,
+    bb_bond_list, bs_bond_list, ss_bond_list,
+    bbb_angle_list, bbs_angle_list, bss_angle_list, sss_angle_list,
+    bbbb_torsion_list, bbbs_torsion_list, bbss_torsion_list,
+    bsss_torsion_list, sbbs_torsion_list) = get_helix_particle_bonded_lists_triangle(cgmodel)
+    
+    # Set up Simulation object beforehand:
+    simulation_time_step = 5.0 * unit.femtosecond
+    friction = 0.0 / unit.picosecond
+    integrator = LangevinIntegrator(
+        0.0 * unit.kelvin, friction, simulation_time_step.in_units_of(unit.picosecond)
+    )
+    simulation = Simulation(cgmodel.topology, cgmodel.system, integrator)    
+    
+    bond_dist_bb = bond_dist_bb.value_in_unit(unit.angstrom)
+
+    params = (simulation, particle_type_list, r, c, n_particle_bb, bond_dist_bb)
+
+    # Set optimization bounds [r_bs, sigma_sc, theta1, theta2]:
+    bounds = [(r/50,5*r),(r/50,5*r),(0,2*np.pi/3),(0,2*np.pi/3)]
+    
+    opt_sol = differential_evolution(
+        compute_helix_openmm_energy_vary_LJ_triangle,
+        bounds,
+        args=params,
+        polish=True,
+        popsize=DE_popsize,
+    )
+    
+    r_bs = opt_sol.x[0]
+    sigma_sc_opt = opt_sol.x[1]
+    r_ss = sigma_sc_opt*np.power(2,(1/6))
+    
+    # Angles of rotation in-plane (x axis) for triangle templates 1 and 2
+    theta1 = opt_sol.x[2]
+    theta2 = opt_sol.x[3]
+       
+    # Compute particle spacing based on bond constraints
+    t_delta_opt = get_t_from_bond_distance(r,c,bond_dist_bb)
+    if t_delta_opt < 0:
+        print(t_delta_opt)
+        t_delta_opt *= -1
+    
+    t_par = np.zeros(n_particle_bb)
+    for i in range(n_particle_bb):
+        t_par[i] = i*t_delta_opt  
+
+    # Equilibrium LJ distance (for visual representation)
+    r_eq_bb = sigma_bb.value_in_unit(unit.angstrom)*np.power(2,(1/6))
+    r_eq_sc = sigma_sc_opt*np.power(2,(1/6))
+    
+    # Get particle positions:
+    xyz = get_helix_coordinates(r,c,t_par)
+    
+    # Place sidechain triangle normal to helix
+    positions = np.zeros((4*n_particle_bb,3))
+
+    # From the law of cosines:
+    if r_bs > r_ss/2:
+        K = np.sqrt(r_bs**2 - (r_ss**2)/4)  # Distance from backbone bead to center of triangle plane
+    else:
+        K = np.sqrt(r_ss**2 - (r_bs**2)/4)
+        
+    L = np.sqrt((r_ss**2)/3)                # Distance from triangle center to lower bead (orientation 1)
+    M = np.sqrt(L**2 - (r_ss**2)/4)         # Distance from triangle center to top of triangle (orientation 1) 
+
+    # To get the coordinates of the triangle, we need to rotate the coordinates 
+    # by the angle separating each residue.
+    
+    # distance between backbone beads projected onto a circle:
+    dist_bb_xy = np.sqrt(np.sum(np.power((xyz[0,0:2]-xyz[1,0:2]),2)))
+    
+    # helical angle between the two backbone beads projected onto a circle:
+    theta_arc = np.arccos(1-dist_bb_xy**2/(2*(r**2))) # radians
+
+    # loop over all residues, rotating the reference triangles about the z axis by theta_arc:
+    
+    # Orientation 1:
+    tri_ref_orient1 = np.zeros((3,3))
+    
+    tri_ref_orient1[0,0] = (1+K/r)*xyz[0,0]
+    tri_ref_orient1[0,1] = (1+K/r)*xyz[0,1] - r_ss/2
+    tri_ref_orient1[0,2] = xyz[0,2] + M
+    
+    tri_ref_orient1[1,0] = (1+K/r)*xyz[0,0] 
+    tri_ref_orient1[1,1] = (1+K/r)*xyz[0,1] + r_ss/2
+    tri_ref_orient1[1,2] = xyz[0,2] + M
+
+    tri_ref_orient1[2,0] = (1+K/r)*xyz[0,0]
+    tri_ref_orient1[2,1] = (1+K/r)*xyz[0,1]
+    tri_ref_orient1[2,2] = xyz[0,2] - L  
+    
+    # Apply the rotation in x:
+    tri_ref_no_rotate1 = tri_ref_orient1
+    
+    tri_ref_orient1[0,:] = rotate_coordinates_x(tri_ref_orient1[0,:],theta1)
+    tri_ref_orient1[1,:] = rotate_coordinates_x(tri_ref_orient1[1,:],theta1)
+    tri_ref_orient1[2,:] = rotate_coordinates_x(tri_ref_orient1[2,:],theta1)
+    
+    # Orientation 2:
+    tri_ref_orient2 = np.zeros((3,3))
+    
+    tri_ref_orient2[0,0] = (1+K/r)*xyz[0,0]
+    tri_ref_orient2[0,1] = (1+K/r)*xyz[0,1] - r_ss/2
+    tri_ref_orient2[0,2] = xyz[0,2] - M
+    
+    tri_ref_orient2[1,0] = (1+K/r)*xyz[0,0]
+    tri_ref_orient2[1,1] = (1+K/r)*xyz[0,1] + r_ss/2
+    tri_ref_orient2[1,2] = xyz[0,2] - M
+
+    tri_ref_orient2[2,0] = (1+K/r)*xyz[0,0]
+    tri_ref_orient2[2,1] = (1+K/r)*xyz[0,1]
+    tri_ref_orient2[2,2] = xyz[0,2] + L
+        
+    # Apply the rotation in x:
+    tri_ref_no_rotate2 = tri_ref_orient2
+    
+    tri_ref_orient2[0,:] = rotate_coordinates_x(tri_ref_orient2[0,:],theta2)
+    tri_ref_orient2[1,:] = rotate_coordinates_x(tri_ref_orient2[1,:],theta2)
+    tri_ref_orient2[2,:] = rotate_coordinates_x(tri_ref_orient2[2,:],theta2)        
+        
+    z_rise = xyz[1,2] - xyz[0,2]    
+        
+    j = -1
+    for i in range(n_particle_bb):
+        if i % 2 == 0:
+            # Orientation 1:
+            j += 1
+            positions[j] = xyz[i]
+            
+            j += 1
+            triangle_xyz_a = rotate_coordinates_z(tri_ref_orient1[0,:],theta_arc*i)
+            triangle_xyz_b = rotate_coordinates_z(tri_ref_orient1[1,:],theta_arc*i)
+            triangle_xyz_c = rotate_coordinates_z(tri_ref_orient1[2,:],theta_arc*i)
+            
+            # Use only the x and y from the rotated reference:
+            positions[j] = triangle_xyz_a
+            positions[j,2] = triangle_xyz_a[2] + z_rise*i
+            
+            j += 1
+            positions[j] = triangle_xyz_b
+            positions[j,2] = triangle_xyz_b[2] + z_rise*i
+            
+            j += 1
+            positions[j] = triangle_xyz_c
+            positions[j,2] = triangle_xyz_c[2] + z_rise*i
+            
+            
+        else:
+            # Orientation 2:
+            j += 1
+            positions[j] = xyz[i]
+            
+            j += 1
+            triangle_xyz_a = rotate_coordinates_z(tri_ref_orient2[0,:],theta_arc*i)
+            triangle_xyz_b = rotate_coordinates_z(tri_ref_orient2[1,:],theta_arc*i)
+            triangle_xyz_c = rotate_coordinates_z(tri_ref_orient2[2,:],theta_arc*i)
+            
+            # Use only the x and y from the rotated reference:
+            positions[j] = triangle_xyz_a
+            positions[j,2] = triangle_xyz_a[2] + z_rise*i
+            
+            j += 1
+            positions[j] = triangle_xyz_b
+            positions[j,2] = triangle_xyz_b[2] + z_rise*i
+            
+            j += 1
+            positions[j] = triangle_xyz_c
+            positions[j,2] = triangle_xyz_c[2] + z_rise*i
+            
+    
+    # Write pdb file
+    cgmodel.positions = positions * unit.angstrom
+    write_pdbfile_without_topology(cgmodel, pdbfile)
+    
+    # Also write dcd file (better precision)
+    dcdfile = pdbfile[:-3]+'dcd'
+    dcdtraj = md.Trajectory(
+        xyz=positions,
+        topology=md.Topology.from_openmm(cgmodel.topology),
+    )
+    md.Trajectory.save_dcd(dcdtraj,dcdfile)    
+    
+    # Store key geometric parameters
+    geometry = {}
+    
+    geometry['sigma_bb'] = sigma_bb.in_units_of(r_unit)
+    geometry['sigma_sc'] = (sigma_sc_opt*unit.angstrom).in_units_of(r_unit)
+    
+    # Add back units:
+    geometry['helical_radius'] = r * r_unit
+    geometry['particle_spacing'] = t_delta_opt * unit.radian
+    geometry['pitch'] = (2*np.pi*c) * r_unit
+        
+    # Load dcd file into mdtraj
+    traj = md.load(dcdfile,top=md.Topology.from_openmm(cgmodel.topology))
+    
+    # Get bb-bb bond distance
+    geometry['bb_bb_distance'] = (dist_unitless(positions[bb_bond_list[0][0],:],positions[bb_bond_list[0][1],:]) * unit.angstrom).in_units_of(r_unit)
+    geometry['bb_sc_distance'] = (dist_unitless(positions[bs_bond_list[0][0],:],positions[bs_bond_list[0][1],:]) * unit.angstrom).in_units_of(r_unit)
+    geometry['sc_sc_distance'] = (dist_unitless(positions[ss_bond_list[0][0],:],positions[ss_bond_list[0][1],:]) * unit.angstrom).in_units_of(r_unit) 
+    
+    # Get bb-bb-bb angle
+    angle_indices = np.array([[bbb_angle_list[0][0], bbb_angle_list[0][1], bbb_angle_list[0][2]]])
+    geometry['bb_bb_bb_angle'] = (md.compute_angles(traj,angle_indices)*unit.radians).in_units_of(unit.degrees)[0][0]
+    
+    # Get bb-bb-sc angle (orientation 1)
+    angle_indices = np.array([[bbs_angle_list[0][0], bbs_angle_list[0][1], bbs_angle_list[0][2]]])
+    geometry['bb_bb_sc_angle_type1'] = (md.compute_angles(traj,angle_indices)*unit.radians).in_units_of(unit.degrees)[0][0]
+    
+    # Get bb-bb-sc angle (orientation 2)
+    angle_indices = np.array([[bbs_angle_list[1][0], bbs_angle_list[1][1], bbs_angle_list[1][2]]])
+    geometry['bb_bb_sc_angle_type2'] = (md.compute_angles(traj,angle_indices)*unit.radians).in_units_of(unit.degrees)[0][0]    
+    
+    # Get bb-sc-sc angle (orientation 1)
+    angle_indices = np.array([[bss_angle_list[0][0], bss_angle_list[0][1], bss_angle_list[0][2]]])
+    geometry['bb_sc_sc_angle_type1'] = (md.compute_angles(traj,angle_indices)*unit.radians).in_units_of(unit.degrees)[0][0]    
+    
+    # Get bb-sc-sc angle (orientation 2)
+    angle_indices = np.array([[bss_angle_list[1][0], bss_angle_list[1][1], bss_angle_list[1][2]]])
+    geometry['bb_sc_sc_angle_type2'] = (md.compute_angles(traj,angle_indices)*unit.radians).in_units_of(unit.degrees)[0][0]      
+    
+    # Get sc-sc-sc angle (orientation 1)
+    angle_indices = np.array([[sss_angle_list[0][0], sss_angle_list[0][1], sss_angle_list[0][2]]])
+    geometry['sc_sc_sc_angle_type1'] = (md.compute_angles(traj,angle_indices)*unit.radians).in_units_of(unit.degrees)[0][0]  
+    
+    # Get sc-sc-sc angle (orientation 2)
+    angle_indices = np.array([[sss_angle_list[1][0], sss_angle_list[1][1], sss_angle_list[1][2]]])
+    geometry['sc_sc_sc_angle_type2'] = (md.compute_angles(traj,angle_indices)*unit.radians).in_units_of(unit.degrees)[0][0]      
+    
+    # Get bb-bb-bb-bb torsion
+    dihedral_indices = np.array([[bbbb_torsion_list[0][0], bbbb_torsion_list[0][1], bbbb_torsion_list[0][2], bbbb_torsion_list[0][3]]])
+    geometry['bb_bb_bb_bb_angle'] = (md.compute_dihedrals(traj,dihedral_indices)*unit.radians).in_units_of(unit.degrees)[0][0]
+    
+    # Get bb-bb-bb-sc torsion (orientation 1)
+    dihedral_indices = np.array([[bbbs_torsion_list[0][0], bbbs_torsion_list[0][1], bbbs_torsion_list[0][2], bbbs_torsion_list[0][3]]])
+    geometry['bb_bb_bb_sc_angle_type1'] = (md.compute_dihedrals(traj,dihedral_indices)*unit.radians).in_units_of(unit.degrees)[0][0]    
+    
+    # Get bb-bb-bb-sc torsion (orientation 2)
+    dihedral_indices = np.array([[bbbs_torsion_list[1][0], bbbs_torsion_list[1][1], bbbs_torsion_list[1][2], bbbs_torsion_list[1][3]]])
+    geometry['bb_bb_bb_sc_angle_type2'] = (md.compute_dihedrals(traj,dihedral_indices)*unit.radians).in_units_of(unit.degrees)[0][0]       
+    
+    # Get bb-bb-sc-sc torsion (orientation 1)
+    dihedral_indices = np.array([[bbss_torsion_list[0][0], bbss_torsion_list[0][1], bbss_torsion_list[0][2], bbss_torsion_list[0][3]]])
+    geometry['bb_bb_sc_sc_angle_type1'] = (md.compute_dihedrals(traj,dihedral_indices)*unit.radians).in_units_of(unit.degrees)[0][0]    
+    
+    # Get bb-bb-sc-sc torsion (orientation 2)
+    dihedral_indices = np.array([[bbss_torsion_list[1][0], bbss_torsion_list[1][1], bbss_torsion_list[1][2], bbss_torsion_list[1][3]]])
+    geometry['bb_bb_sc_sc_angle_type2'] = (md.compute_dihedrals(traj,dihedral_indices)*unit.radians).in_units_of(unit.degrees)[0][0]  
+
+    # Get bb-sc-sc-sc torsion (orientation 1)
+    dihedral_indices = np.array([[bsss_torsion_list[0][0], bsss_torsion_list[0][1], bsss_torsion_list[0][2], bsss_torsion_list[0][3]]])
+    geometry['bb_sc_sc_sc_angle_type1'] = (md.compute_dihedrals(traj,dihedral_indices)*unit.radians).in_units_of(unit.degrees)[0][0]   
+    
+    # Get bb-sc-sc-sc torsion (orientation 2)
+    dihedral_indices = np.array([[bsss_torsion_list[1][0], bsss_torsion_list[1][1], bsss_torsion_list[1][2], bsss_torsion_list[1][3]]])
+    geometry['bb_sc_sc_sc_angle_type2'] = (md.compute_dihedrals(traj,dihedral_indices)*unit.radians).in_units_of(unit.degrees)[0][0]      
+    
+    # Get sc-bb-bb-sc torsion
+    dihedral_indices = np.array([[sbbs_torsion_list[0][0], sbbs_torsion_list[0][1], sbbs_torsion_list[0][2], sbbs_torsion_list[0][3]]])
+    geometry['sc_bb_bb_sc_angle'] = (md.compute_dihedrals(traj,dihedral_indices)*unit.radians).in_units_of(unit.degrees)[0][0]
+
+    # # Plot helix:
+    # if plotfile is not None:
+        # plot_LJ_helix(r,c,t_par,r_eq_bb,r_eq_sc=r_eq_sc,plotfile=plotfile)
+    
+    return opt_sol, geometry
+
+
 def compute_helix_openmm_energy_vary_LJ(geo, simulation, bb_array, sc_array, 
     particle_type_list, r, c, n_particle_bb):
     """
@@ -258,7 +588,8 @@ def compute_helix_openmm_energy_vary_LJ(geo, simulation, bb_array, sc_array,
         
     # If the bonds, angles, and backbone torsions are at their equilibrium positions,
     # then we don't need to update any parameters in the simulation object. Just
-    # the nonbonded energies need to be evaluated.
+    # the nonbonded energies need to be evaluated. In the cgmodel, all force constants
+    # are zero.
         
     # Place sidechain particles normal to helix with same bond length as bb_bb
     r_bs = dist_unitless(xyz[0,:],xyz[1,:])
@@ -299,6 +630,40 @@ def compute_helix_openmm_energy_vary_LJ(geo, simulation, bb_array, sc_array,
         
     return U_helix    
     
+
+def rotate_coordinates_z(xyz,theta):
+    """
+    Internal function for rotating 3d coordinates by theta (angle between adjacent residues)
+    Theta is specified in radians.
+    """
+    
+    R_mat = np.array([
+        [np.cos(theta), -np.sin(theta), 0],
+        [np.sin(theta),  np.cos(theta), 0],
+        [0, 0, 1]
+        ])
+
+    xyz_rot = np.matmul(R_mat, xyz)    
+    
+    return xyz_rot
+    
+    
+def rotate_coordinates_x(xyz,theta):
+    """
+    Internal function for rotating 3d coordinates by theta (angle to rotate the triangle in-plane)
+    Theta is specified in radians.
+    """
+    
+    R_mat = np.array([
+        [1, 0, 0],
+        [0, np.cos(theta), -np.sin(theta)],
+        [0, np.sin(theta),  np.cos(theta)],
+        ])
+
+    xyz_rot = np.matmul(R_mat, xyz)
+    
+    return xyz_rot    
+    
     
 def compute_helix_openmm_energy_vary_LJ_constrained(
     geo, simulation, bb_array, sc_array, particle_type_list, r, c, n_particle_bb, bond_dist_bb, bond_dist_sc):
@@ -323,7 +688,8 @@ def compute_helix_openmm_energy_vary_LJ_constrained(
         
     # If the bonds, angles, and backbone torsions are at their equilibrium positions,
     # then we don't need to update any parameters in the simulation object. Just
-    # the nonbonded energies need to be evaluated.
+    # the nonbonded energies need to be evaluated. In the cgmodel, all force constants
+    # are zero.
         
     # Place sidechain particles normal to helix with same bond length as bb_bb
     r_bs = bond_dist_sc
@@ -365,3 +731,171 @@ def compute_helix_openmm_energy_vary_LJ_constrained(
     return U_helix    
     
         
+def compute_helix_openmm_energy_vary_LJ_triangle(
+    geo, simulation, particle_type_list, r, c, n_particle_bb, bond_dist_bb):
+    """
+    Internal function for computing openmm energy of Lennard-Jones 12-6 helix
+    """
+    
+    # Backbone-sidechain bond length:
+    r_bs = geo[0]
+    
+    # Sidechain sigma parameter
+    sigma_sc = geo[1] * unit.angstrom
+    
+    # Angle of rotation in x for each triangle reference:
+    theta1 = geo[2]
+    theta2 = geo[3]
+    
+    # sidechain-sidechain bond length:
+    r_ss = sigma_sc.value_in_unit(unit.angstrom)*np.power(2,(1/6))
+    
+    # Particle spacing (radians)
+    t_delta = get_t_from_bond_distance(r,c,bond_dist_bb)
+    
+    t1 = np.zeros(n_particle_bb)
+    for i in range(n_particle_bb):
+        t1[i] = i*t_delta
+        
+    xyz = get_helix_coordinates(r,c,t1)
+        
+    # If the bonds, angles, and backbone torsions are at their equilibrium positions,
+    # then we don't need to update any parameters in the simulation object. Just
+    # the nonbonded energies need to be evaluated. In the cgmodel, all force constants
+    # are zero.
+        
+    # Place sidechain triangle normal to helix
+    positions = np.zeros((4*n_particle_bb,3))
+
+    # From the law of cosines:
+    if r_bs > r_ss/2:
+        K = np.sqrt(r_bs**2 - (r_ss**2)/4) 
+    else:
+        K = np.sqrt(r_ss**2 - (r_bs**2)/4)
+        
+    L = np.sqrt((r_ss**2)/3)
+    M = np.sqrt(L**2 - (r_ss**2)/4)
+    
+    # To get the coordinates of the triangle, we need to rotate the coordinates 
+    # by the angle separating each residue.
+    
+    # distance between backbone beads projected onto a circle:
+    dist_bb_xy = np.sqrt(np.sum(np.power((xyz[0,0:2]-xyz[1,0:2]),2)))
+    
+    # helical angle between the two backbone beads projected onto a circle:
+    theta_arc = np.arccos(1-dist_bb_xy**2/(2*(r**2))) # radians
+    
+    # loop over all residues, rotating the reference triangles about the z axis by theta_arc:
+    
+    # Orientation 1:
+    tri_ref_orient1 = np.zeros((3,3))
+    
+    tri_ref_orient1[0,0] = (1+K/r)*xyz[0,0]
+    tri_ref_orient1[0,1] = (1+K/r)*xyz[0,1] - r_ss/2
+    tri_ref_orient1[0,2] = xyz[0,2] + M
+    
+    tri_ref_orient1[1,0] = (1+K/r)*xyz[0,0] 
+    tri_ref_orient1[1,1] = (1+K/r)*xyz[0,1] + r_ss/2
+    tri_ref_orient1[1,2] = xyz[0,2] + M
+
+    tri_ref_orient1[2,0] = (1+K/r)*xyz[0,0]
+    tri_ref_orient1[2,1] = (1+K/r)*xyz[0,1]
+    tri_ref_orient1[2,2] = xyz[0,2] - L  
+    
+    # Apply the rotation in x:
+    tri_ref_no_rotate1 = tri_ref_orient1
+    
+    tri_ref_orient1[0,:] = rotate_coordinates_x(tri_ref_orient1[0,:],theta1)
+    tri_ref_orient1[1,:] = rotate_coordinates_x(tri_ref_orient1[1,:],theta1)
+    tri_ref_orient1[2,:] = rotate_coordinates_x(tri_ref_orient1[2,:],theta1)    
+    
+    # Orientation 2:
+    tri_ref_orient2 = np.zeros((3,3))
+    
+    tri_ref_orient2[0,0] = (1+K/r)*xyz[0,0]
+    tri_ref_orient2[0,1] = (1+K/r)*xyz[0,1] - r_ss/2
+    tri_ref_orient2[0,2] = xyz[0,2] - M
+    
+    tri_ref_orient2[1,0] = (1+K/r)*xyz[0,0]
+    tri_ref_orient2[1,1] = (1+K/r)*xyz[0,1] + r_ss/2
+    tri_ref_orient2[1,2] = xyz[0,2] - M
+
+    tri_ref_orient2[2,0] = (1+K/r)*xyz[0,0]
+    tri_ref_orient2[2,1] = (1+K/r)*xyz[0,1]
+    tri_ref_orient2[2,2] = xyz[0,2] + L  
+    
+    # Apply the rotation in x:
+    tri_ref_no_rotate2 = tri_ref_orient2
+    
+    tri_ref_orient2[0,:] = rotate_coordinates_x(tri_ref_orient2[0,:],theta2)
+    tri_ref_orient2[1,:] = rotate_coordinates_x(tri_ref_orient2[1,:],theta2)
+    tri_ref_orient2[2,:] = rotate_coordinates_x(tri_ref_orient2[2,:],theta2)  
+
+    z_rise = xyz[1,2] - xyz[0,2]
+        
+    j = -1
+    for i in range(n_particle_bb):
+        if i % 2 == 0:
+            # Orientation 1:
+            j += 1
+            positions[j] = xyz[i]
+            
+            j += 1
+            triangle_xyz_a = rotate_coordinates_z(tri_ref_orient1[0,:],theta_arc*i)
+            triangle_xyz_b = rotate_coordinates_z(tri_ref_orient1[1,:],theta_arc*i)
+            triangle_xyz_c = rotate_coordinates_z(tri_ref_orient1[2,:],theta_arc*i)
+            
+            # Use only the x and y from the rotated reference:
+            positions[j] = triangle_xyz_a
+            positions[j,2] = triangle_xyz_a[2] + z_rise*i
+            
+            j += 1
+            positions[j] = triangle_xyz_b
+            positions[j,2] = triangle_xyz_b[2] + z_rise*i
+            
+            j += 1
+            positions[j] = triangle_xyz_c
+            positions[j,2] = triangle_xyz_c[2] + z_rise*i
+            
+            
+        else:
+            # Orientation 2:
+            j += 1
+            positions[j] = xyz[i]
+            
+            j += 1
+            triangle_xyz_a = rotate_coordinates_z(tri_ref_orient2[0,:],theta_arc*i)
+            triangle_xyz_b = rotate_coordinates_z(tri_ref_orient2[1,:],theta_arc*i)
+            triangle_xyz_c = rotate_coordinates_z(tri_ref_orient2[2,:],theta_arc*i)
+            
+            # Use only the x and y from the rotated reference:
+            positions[j] = triangle_xyz_a
+            positions[j,2] = triangle_xyz_a[2] + z_rise*i
+            
+            j += 1
+            positions[j] = triangle_xyz_b
+            positions[j,2] = triangle_xyz_b[2] + z_rise*i
+            
+            j += 1
+            positions[j] = triangle_xyz_c
+            positions[j,2] = triangle_xyz_c[2] + z_rise*i
+    
+    positions *= unit.angstrom
+    
+    # Update the nonbonded parameters:
+    for force_index, force in enumerate(simulation.system.getForces()):
+        force_name = force.__class__.__name__
+        if force_name == 'NonbondedForce':
+            for particle_index in range(len(particle_type_list)):
+                (q,sigma_old,eps) = force.getParticleParameters(particle_index)
+                
+                # Only need to change the sigma_sc values here:
+                force.setParticleParameters(particle_index,q,sigma_sc,eps)
+                force.updateParametersInContext(simulation.context)
+            
+    # Update the positions:        
+    simulation.context.setPositions(positions)
+    potential_energy = simulation.context.getState(getEnergy=True).getPotentialEnergy()
+    U_helix = potential_energy.value_in_unit(unit.kilojoules_per_mole)
+   
+    return U_helix            

--- a/cg_openmm/utilities/helix_utils.py
+++ b/cg_openmm/utilities/helix_utils.py
@@ -143,10 +143,307 @@ def get_helix_cgmodel(sigma_bb,sigma_sc,epsilon_bb,epsilon_sc,n_particle_bb):
     return cgmodel
     
     
+def get_helix_cgmodel_2sc_equal(sigma_bb,sigma_sc,epsilon_bb,epsilon_sc,n_particle_bb):
+    """
+    Internal function for creating a cgmodel with 1 backbone bead, 2 sidechain beads
+    and with 1-3 nonbonded interactions included for bb-sc and sc-sc pairs,
+    to use in helical optimization.
+    (equal sigma_sc for each sidechain particle)
+    """
+
+    #--------------------------------------------#
+    # Particle definitions and oligomer topology #
+    #--------------------------------------------#
+
+    mass = 100.0 * unit.amu
+
+    # Mass and charge are defaults.
+    # Backbone particle:
+    bb = {
+        "particle_type_name": "bb",
+        "sigma": sigma_bb, # angstrom
+        "epsilon": epsilon_bb, # kilojoules_per_mole
+        "mass": mass
+    }
+        
+    # Sidechain particle:
+    sc = {
+        "particle_type_name": "sc",
+        "sigma": sigma_sc, # angstrom,
+        "epsilon": epsilon_sc, # kilojoules_per_mole,
+        "mass": mass
+    }
+
+    # Monomer definition:
+    A = {
+        "monomer_name": "A",
+        "particle_sequence": [bb, sc, sc],
+        "bond_list": [[0, 1],[1,2]],
+        "start": 0,
+        "end": 0,
+    }
+
+    # Residue sequence:
+    sequence = n_particle_bb * [A]
+
+    # Exclusion rules:
+    exclusions = {
+        "default_exclusions": [0,1,1],
+        "bb_bb_exclusions": [0,0,1],
+        }
+
+    #--------------------------#
+    # Harmonic bond parameters #
+    #--------------------------#
+
+    # Bond definitions:
+    bond_lengths = {"default_bond_length": 2.44 * unit.angstrom}
+
+    bond_force_constants = {
+        "default_bond_force_constant": 0 * unit.kilojoule_per_mole / unit.nanometer / unit.nanometer
+    }
+
+    #---------------------------#
+    # Harmonic angle parameters #
+    #---------------------------#
+
+    # Bond angle definitions:
+    bond_angle_force_constants = {
+        "default_bond_angle_force_constant": 0 * unit.kilojoule_per_mole / unit.radian / unit.radian
+    }
+
+    equil_bond_angles = {
+        "default_equil_bond_angle": 127.5 * unit.degrees,
+        "bb_bb_bb_equil_bond_angle": 105.5 * unit.degrees}
+
+    #-----------------------------#
+    # Periodic torsion parameters #
+    #-----------------------------#    
+        
+    # Torsion angle definitions:
+    torsion_force_constants = {
+        "default_torsion_force_constant": 0.0 * unit.kilojoule_per_mole,
+    }
+
+    torsion_phase_angles = {
+        "sc_bb_bb_sc_torsion_phase_angle": 0 * unit.degrees,
+        "bb_bb_bb_bb_torsion_phase_angle": (16.7-180) * unit.degrees,
+        "bb_bb_bb_sc_torsion_phase_angle": 0 * unit.degrees,
+    }
+
+    torsion_periodicities = {
+        "default_torsion_periodicity": 1,
+    }
+
+    # Set initial positions for cgmodel
+    # These are arbitrary - we just can't have overlapping beads
+    # The particles in cgmodel get ordered as bb,sc,sc,bb,sc,sc...
+    positions_init = np.zeros((3*n_particle_bb,3))
+    
+    t0 = np.zeros(n_particle_bb)
+    for i in range(n_particle_bb):
+        t0[i] = i*np.pi/5
+        
+    xyz_bb = get_helix_coordinates(1,1,t0)
+    
+    j = -1
+    for i in range(n_particle_bb):
+        j += 1
+        positions_init[j,:] = xyz_bb[i,:]
+        
+        j += 1
+        positions_init[j,0] = 2*xyz_bb[i,0]
+        positions_init[j,1] = 2*xyz_bb[i,1]
+        positions_init[j,2] = xyz_bb[i,2]
+        
+        j += 1
+        positions_init[j,0] = 3*xyz_bb[i,0]
+        positions_init[j,1] = 3*xyz_bb[i,1]
+        positions_init[j,2] = xyz_bb[i,2]
+
+    positions_init *= unit.angstrom
+    
+    # Build a coarse grained model:
+    cgmodel = CGModel(
+        particle_type_list=[bb, sc],
+        bond_lengths=bond_lengths,
+        bond_force_constants=bond_force_constants,
+        bond_angle_force_constants=bond_angle_force_constants,
+        torsion_force_constants=torsion_force_constants,
+        equil_bond_angles=equil_bond_angles,
+        torsion_phase_angles=torsion_phase_angles,
+        torsion_periodicities=torsion_periodicities,
+        include_nonbonded_forces=True,
+        include_bond_forces=True,
+        include_bond_angle_forces=True,
+        include_torsion_forces=False,
+        constrain_bonds=False,
+        exclusions=exclusions,
+        positions=positions_init,
+        sequence=sequence,
+        monomer_types=[A],
+    )
+
+    return cgmodel        
+    
+    
+def get_helix_cgmodel_2sc_nonequal(sigma_bb,sigma_sc,epsilon_bb,epsilon_sc,n_particle_bb):
+    """
+    Internal function for creating a cgmodel with 1 backbone bead, 2 sidechain beads
+    and with 1-3 nonbonded interactions included for bb-sc and sc-sc pairs,
+    to use in helical optimization.
+    (different sigma_sc for each sidechain particle)
+    """
+
+    #--------------------------------------------#
+    # Particle definitions and oligomer topology #
+    #--------------------------------------------#
+
+    mass = 100.0 * unit.amu
+
+    # Mass and charge are defaults.
+    # Backbone particle:
+    bb = {
+        "particle_type_name": "bb",
+        "sigma": sigma_bb, # angstrom
+        "epsilon": epsilon_bb, # kilojoules_per_mole
+        "mass": mass
+    }
+        
+    # Sidechain particle:
+    # Initially, set the sidechain sigmas equal
+    sc1 = {
+        "particle_type_name": "sc1",
+        "sigma": sigma_sc, # angstrom,
+        "epsilon": epsilon_sc, # kilojoules_per_mole,
+        "mass": mass
+    }
+    
+    # Sidechain particle:
+    sc2 = {
+        "particle_type_name": "sc2",
+        "sigma": sigma_sc, # angstrom,
+        "epsilon": epsilon_sc, # kilojoules_per_mole,
+        "mass": mass
+    }    
+
+    # Monomer definition:
+    A = {
+        "monomer_name": "A",
+        "particle_sequence": [bb, sc1, sc2],
+        "bond_list": [[0, 1],[1,2]],
+        "start": 0,
+        "end": 0,
+    }
+
+    # Residue sequence:
+    sequence = n_particle_bb * [A]
+
+    # Exclusion rules:
+    exclusions = {
+        "default_exclusions": [0,1,1],
+        "bb_bb_exclusions": [0,0,1],
+        }
+
+    #--------------------------#
+    # Harmonic bond parameters #
+    #--------------------------#
+
+    # Bond definitions:
+    bond_lengths = {"default_bond_length": 2.44 * unit.angstrom}
+
+    bond_force_constants = {
+        "default_bond_force_constant": 0 * unit.kilojoule_per_mole / unit.nanometer / unit.nanometer
+    }
+
+    #---------------------------#
+    # Harmonic angle parameters #
+    #---------------------------#
+
+    # Bond angle definitions:
+    bond_angle_force_constants = {
+        "default_bond_angle_force_constant": 0 * unit.kilojoule_per_mole / unit.radian / unit.radian
+    }
+
+    equil_bond_angles = {
+        "default_equil_bond_angle": 127.5 * unit.degrees,
+        "bb_bb_bb_equil_bond_angle": 105.5 * unit.degrees}
+
+    #-----------------------------#
+    # Periodic torsion parameters #
+    #-----------------------------#    
+        
+    # Torsion angle definitions:
+    torsion_force_constants = {
+        "default_torsion_force_constant": 0.0 * unit.kilojoule_per_mole,
+    }
+
+    torsion_phase_angles = {
+        "default_torsion_phase_angle": 0 * unit.degrees,
+        "bb_bb_bb_bb_torsion_phase_angle": (16.7-180) * unit.degrees,
+    }
+
+    torsion_periodicities = {
+        "default_torsion_periodicity": 1,
+    }
+
+    # Set initial positions for cgmodel
+    # These are arbitrary - we just can't have overlapping beads
+    # The particles in cgmodel get ordered as bb,sc,sc,bb,sc,sc...
+    positions_init = np.zeros((3*n_particle_bb,3))
+    
+    t0 = np.zeros(n_particle_bb)
+    for i in range(n_particle_bb):
+        t0[i] = i*np.pi/5
+        
+    xyz_bb = get_helix_coordinates(1,1,t0)
+    
+    j = -1
+    for i in range(n_particle_bb):
+        j += 1
+        positions_init[j,:] = xyz_bb[i,:]
+        
+        j += 1
+        positions_init[j,0] = 2*xyz_bb[i,0]
+        positions_init[j,1] = 2*xyz_bb[i,1]
+        positions_init[j,2] = xyz_bb[i,2]
+        
+        j += 1
+        positions_init[j,0] = 3*xyz_bb[i,0]
+        positions_init[j,1] = 3*xyz_bb[i,1]
+        positions_init[j,2] = xyz_bb[i,2]
+
+    positions_init *= unit.angstrom
+    
+    # Build a coarse grained model:
+    cgmodel = CGModel(
+        particle_type_list=[bb, sc1, sc2],
+        bond_lengths=bond_lengths,
+        bond_force_constants=bond_force_constants,
+        bond_angle_force_constants=bond_angle_force_constants,
+        torsion_force_constants=torsion_force_constants,
+        equil_bond_angles=equil_bond_angles,
+        torsion_phase_angles=torsion_phase_angles,
+        torsion_periodicities=torsion_periodicities,
+        include_nonbonded_forces=True,
+        include_bond_forces=True,
+        include_bond_angle_forces=True,
+        include_torsion_forces=False,
+        constrain_bonds=False,
+        exclusions=exclusions,
+        positions=positions_init,
+        sequence=sequence,
+        monomer_types=[A],
+    )
+
+    return cgmodel            
+    
+    
 def get_helix_cgmodel_triangle(sigma_bb,sigma_sc,epsilon_bb,epsilon_sc,n_particle_bb):
     """
     Internal function for creating a cgmodel with 1 backbone bead, 3 sidechain beads in a 
-    triangle and with 1-3 nonbonded interactions included, to use in helical optimization.
+    triangle with 1-3 nonbonded interactions included for bb-sc and sc-sc pairs,
+    to use in helical optimization.
     """
 
     #--------------------------------------------#
@@ -293,6 +590,7 @@ def get_helix_cgmodel_triangle(sigma_bb,sigma_sc,epsilon_bb,epsilon_sc,n_particl
 def get_helix_particle_bonded_lists(cgmodel):
     """
     Internal function for getting particle type list and bonded lists
+    (1sc model)
     """
 
     particle_list = cgmodel.create_particle_list()
@@ -372,9 +670,118 @@ def get_helix_particle_bonded_lists(cgmodel):
             bbbb_torsion_list, bbbs_torsion_list, sbbs_torsion_list)
     
     
-def get_helix_particle_bonded_lists_triangle(cgmodel):
+def get_helix_particle_bonded_lists_2sc(cgmodel):
     """
     Internal function for getting particle type list and bonded lists
+    (2sc model)
+    """
+
+    particle_list = cgmodel.create_particle_list()
+    
+    particle_type_list = []
+    
+    bb_list = []
+    sc_list = []
+    
+    # Use particle indices rather than the full particle dictionary:
+    for par in range(len(particle_list)):
+        if cgmodel.get_particle_type_name(par) == 'bb':
+            bb_list.append(par)
+            particle_type_list.append('bb')
+        elif cgmodel.get_particle_type_name(par) == 'sc':
+            sc_list.append(par)
+            particle_type_list.append('sc')
+        elif cgmodel.get_particle_type_name(par) == 'sc1':
+            sc_list.append(par)
+            particle_type_list.append('sc1')   
+        elif cgmodel.get_particle_type_name(par) == 'sc2':
+            sc_list.append(par)
+            particle_type_list.append('sc2')              
+    
+    # Use arrays for particle type indices
+    bb_array = np.asarray(bb_list)
+    sc_array = np.asarray(sc_list)
+    
+    # Create bond list for each type:
+    bond_list = cgmodel.get_bond_list()
+        
+    bb_bond_list = []
+    bs_bond_list = []
+    ss_bond_list = []
+    
+    for bond in bond_list:
+        type1 = cgmodel.get_particle_type_name(bond[0])
+        type2 = cgmodel.get_particle_type_name(bond[1])
+        
+        if type1 == 'bb' and type2 == 'bb':
+            bb_bond_list.append(bond)
+        elif (type1 == 'bb' and type2 in ['sc','sc1','sc2']) or \
+            (type2 == 'bb' and type1 in ['sc','sc1','sc2']):
+            bs_bond_list.append(bond)
+        elif type1 in ['sc','sc1','sc2'] and type2 in ['sc','sc1','sc2']:
+            ss_bond_list.append(bond)
+            
+    # Create angle list for each type:
+    angle_list = cgmodel.get_bond_angle_list()
+    
+    bbb_angle_list = []
+    bbs_angle_list = []
+    bss_angle_list = []
+    
+    for angle in angle_list:
+        type1 = cgmodel.get_particle_type_name(angle[0])
+        type2 = cgmodel.get_particle_type_name(angle[1])
+        type3 = cgmodel.get_particle_type_name(angle[2])
+        
+        if type1 == 'bb' and type2 == 'bb' and type3 == 'bb':
+            bbb_angle_list.append(angle)
+            
+        elif (type1 == 'bb' and type2 == 'bb' and type3 in ['sc','sc1','sc2']) or \
+            (type1 in ['sc','sc1','sc2'] and type2 == 'bb' and type3 == 'bb'):
+            bbs_angle_list.append(angle)
+            
+        elif (type1 == 'bb' and type2 in ['sc','sc1','sc2'] and type3 in ['sc','sc1','sc2']) or \
+            (type1 in ['sc','sc1','sc2'] and type2 in ['sc','sc1','sc2'] and type3 == 'bb'):
+            bss_angle_list.append(angle)
+    
+    # Create torsion list for each type:
+    torsion_list = cgmodel.get_torsion_list()
+    
+    bbbb_torsion_list = []
+    bbbs_torsion_list = []
+    bbss_torsion_list = []
+    sbbs_torsion_list = []
+    
+    for torsion in torsion_list:
+        type1 = cgmodel.get_particle_type_name(torsion[0])
+        type2 = cgmodel.get_particle_type_name(torsion[1])
+        type3 = cgmodel.get_particle_type_name(torsion[2])
+        type4 = cgmodel.get_particle_type_name(torsion[3])
+        
+        if type1 == 'bb' and type2 == 'bb' and type3 == 'bb' and type4 == 'bb':
+            bbbb_torsion_list.append(torsion)
+            
+        elif (type1 == 'bb' and type2 == 'bb' and type3 == 'bb' and type4 in ['sc','sc1','sc2']) or \
+            (type1 in ['sc','sc1','sc2'] and type2 == 'bb' and type3 == 'bb' and type4 == 'bb'):
+            bbbs_torsion_list.append(torsion)
+          
+        elif (type1 == 'bb' and type2 == 'bb' and type3 in ['sc','sc1','sc2'] and type4 in ['sc','sc1','sc2']) or \
+            (type1 in ['sc','sc1','sc2'] and type2 in ['sc','sc1','sc2'] and type3 == 'bb' and type4 == 'bb'):
+            bbss_torsion_list.append(torsion)        
+            
+        elif type1 in ['sc','sc1','sc2'] and type2 == 'bb' and type3 == 'bb' and type4 in ['sc','sc1','sc2']:
+            sbbs_torsion_list.append(torsion)
+    
+    return (particle_type_list, bb_array, sc_array,
+            bb_bond_list, bs_bond_list, ss_bond_list,
+            bbb_angle_list, bbs_angle_list, bss_angle_list,
+            bbbb_torsion_list, bbbs_torsion_list, bbss_torsion_list,
+            sbbs_torsion_list)        
+    
+    
+def get_helix_particle_bonded_lists_triangle(cgmodel):
+    """
+    Internal function for getting particle type list and bonded lists (3sc triangle model)
     """
 
     particle_list = cgmodel.create_particle_list()

--- a/cg_openmm/utilities/helix_utils.py
+++ b/cg_openmm/utilities/helix_utils.py
@@ -1099,3 +1099,69 @@ def plot_LJ_helix(r, c, t_par, r_eq_bb, r_eq_sc=None, plotfile='LJ_helix.pdf'):
     
     return
     
+    
+def write_helix_pdbfile(coordinates, filename, sidechain):
+    """
+    Internal function for writing pdb file of optimized helix
+    (used for the simple helix optimization only)
+    """
+
+    pdb_object = open(filename, "w")
+    particle_list = np.arange(0,coordinates.shape[0],1)
+
+    particle_type_list = [] # Type of each particle
+    monomer_index_list = [] # Residue number of each bead
+
+    if sidechain:
+        mono_id = 0
+        for i in range(int(len(particle_list)/2)):
+            particle_type_list.append('bb')
+            monomer_index_list.append(mono_id)
+            mono_id +=1
+
+        mono_id = 0
+        for i in range(int(len(particle_list)/2)):
+            particle_type_list.append('sc')
+            monomer_index_list.append(mono_id)
+            mono_id +=1
+    else:
+        mono_id = 0
+        for i in range(len(particle_list)):
+            particle_type_list.append('bb')   
+            monomer_index_list.append(mono_id)
+            mono_id +=1            
+
+    for i in range(len(particle_list)):
+        pdb_object.write(
+            f"ATOM{particle_list[i]+1:>7d} {particle_type_list[i]:>3s}{1}   A A{monomer_index_list[i]:>4}    "
+            f"{coordinates[i][0]:>8.3f}"
+            f"{coordinates[i][1]:>8.3f}"
+            f"{coordinates[i][2]:>8.3f}"
+            f"  1.00  0.00\n"
+        )
+    pdb_object.write("TER\n")
+
+    # Add bonds:
+    bond_list = []
+
+    if sidechain:
+        for i in range(int(len(particle_list)/2)-1):
+            bond_list.append([i,i+1])
+        for i in range(int(len(particle_list)/2)):
+            bond_list.append([i,int(i+len(particle_list)/2)])
+    else:
+        for i in range(len(particle_list)-1):
+            bond_list.append([i,i+1])    
+
+    for bond in bond_list:
+        pdb_object.write(
+            "CONECT"
+            + str("{:>5}".format(bond[0] + 1))
+            + str("{:>5}".format(bond[1] + 1))
+            + "\n"
+        )
+    pdb_object.write(str("END\n"))
+
+    pdb_object.close()
+    return    
+    


### PR DESCRIPTION
## Description
Adds new functionality to the helix modeling tools:

1) Function for optimizing bb-sc and sc-sc bond lengths and sigma_sc parameters for 2 sidechain helix models with specified radius, pitch, bb-bb bond length, and sigma_bb (openmm minimum energy objective function), with the option of equal sigma_sc or independent sigma_sc of the two sidechain particles.

2) Function for optimizing nonbonded parameters for 3sc (triangle packing) helix models. With fixed radius, pitch, bb-bb bond length, the variables are bb-sc bond length, sigma_sc, and rotational orientations of odd and even residue index triangles.

3) Function for maximizing the enthalpy of folding between a 1sc helix and extended system (still work in progress). This uses a brute force method in an outer optimization loop for bond lengths, and an inner differential evolution optimization for sigma_bb, sigma_sc. (since we want no repulsive interactions in the unfolded state, the bounds for sigmas depends on the bond lengths in a complex way). Very slow if we apply a finishing minimization to the brute force outer loop. For now, no finishing minimization is done to the bond lengths in the outer loop.

4) Exclusion rules (in the same format that is input into the cgmodel) can now be passed into the helix optimization functions.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Add tests for 2sc optimization
  - [x] Add tests for 3sc optimization
  - [x] Add tests for extended vs helix 1sc optimization

## Status
- [x] Ready to go