### PR TITLE
pymbar 4 update

### DIFF
--- a/cg_openmm/parameters/free_energy.py
+++ b/cg_openmm/parameters/free_energy.py
@@ -66,7 +66,7 @@ def expectations_free_energy(Q, Q_folded, temperature_list, frame_begin=0, sampl
     :param frame_begin: index of first frame defining the range of samples to use as a production period (default=0)
     :type frame_begin: int    
     
-    :param sample_spacing: spacing of uncorrelated data points, for example determined from pymbar timeseries subsampleCorrelatedData
+    :param sample_spacing: spacing of uncorrelated data points, for example determined from pymbar timeseries subsample_correlated_data
     :type sample_spacing: int     
     
     :param output_data: Path to the simulation .nc file.
@@ -186,12 +186,10 @@ def expectations_free_energy(Q, Q_folded, temperature_list, frame_begin=0, sampl
                 ti += 1
                 N_k[k] = n_samples//len(temps)  # these are the states that have samples
 
-    # call MBAR to find weights at all states, sampled and unsampled
-    solver_protocol = {"method":"L-BFGS-B"}
-    
+    # call MBAR to find weights at all states, sampled and unsampled 
     mbarT = pymbar.MBAR(
-        unsampled_state_energies,N_k,verbose=False,relative_tolerance=1e-12,
-        maximum_iterations=10000,solver_protocol=(solver_protocol,),
+        unsampled_state_energies,N_k,relative_tolerance=1e-12,
+        solver_protocol='robust', maximum_iterations=1000000,
         )
         
     # Calculate N expectations that a structure is in configurational state n
@@ -214,7 +212,7 @@ def expectations_free_energy(Q, Q_folded, temperature_list, frame_begin=0, sampl
 
         # compute expectations of being in conformational state n
         # Store results in a dictionary
-        results[str(i)] = mbarT.computeMultipleExpectations(
+        results[str(i)] = mbarT.compute_multiple_expectations(
             bool_i,U_n,compute_covariance=True)
 
     deltaF_values = {}
@@ -236,11 +234,11 @@ def expectations_free_energy(Q, Q_folded, temperature_list, frame_begin=0, sampl
                 # Free energy change for s2 --> s1 at temp i
                 deltaF_values[f"state{s1}_state{s2}"][i] = (
                     -kB*full_T_list[i]*Tunit*(
-                    np.log(results[str(i)][0][s1])-
-                    np.log(results[str(i)][0][s2]))).value_in_unit(F_unit)
+                    np.log(results[str(i)]['mu'][s1])-
+                    np.log(results[str(i)]['mu'][s2]))).value_in_unit(F_unit)
                     
                 # Get covariance matrix:
-                theta_i = results[str(i)][2]
+                theta_i = results[str(i)]['covariances']
                 deltaF_uncertainty[f"state{s1}_state{s2}"][i] = (
                     kB*full_T_list[i]*unit.kelvin*np.sqrt(
                     theta_i[s1,s1] + theta_i[s2,s2] - (theta_i[s2,s1]+theta_i[s1,s2]))).value_in_unit(F_unit)
@@ -275,7 +273,7 @@ def bootstrap_free_energy_folding(Q, Q_folded, array_folded_states=None, output_
     :param frame_begin: index of first frame defining the range of samples to use as a production period (default=0)
     :type frame_begin: int    
     
-    :param sample_spacing: spacing of uncorrelated data points, for example determined from pymbar timeseries subsampleCorrelatedData
+    :param sample_spacing: spacing of uncorrelated data points, for example determined from pymbar timeseries subsample_correlated_data
     :type sample_spacing: int     
     
     :param n_trial_boot: number of trials to run for generating bootstrapping uncertainties (default=200)

--- a/cg_openmm/parameters/reweight.py
+++ b/cg_openmm/parameters/reweight.py
@@ -14,7 +14,7 @@ kB = (unit.MOLAR_GAS_CONSTANT_R).in_units_of(unit.kilojoule / (unit.kelvin * uni
 
 def bin_samples(sample_kn, n_bins):
     """
-        """
+    """
     max_value, min_value = None, None
     for index_1 in range(len(sample_kn)):
         for index_2 in range(len(sample_kn[index_1])):
@@ -43,20 +43,20 @@ def bin_samples(sample_kn, n_bins):
 
 def get_decorrelated_samples(replica_positions, replica_energies, temperature_list):
     """
-        Given a set of replica exchange trajectories, energies, and associated temperatures, this function returns decorrelated samples, as obtained from pymbar with timeseries.subsampleCorrelatedData.
+    Given a set of replica exchange trajectories, energies, and associated temperatures, this function returns decorrelated samples, as obtained from pymbar with timeseries.subsample_correlated_data.
 
-        :param replica_positions: Positions array for the replica exchange data for which we will write PDB files
-        :type replica_positions: `Quantity() <http://docs.openmm.org/development/api-python/generated/simtk.unit.quantity.Quantity.html>`_ ( np.array( [n_replicas,cgmodel.num_beads,3] ), simtk.unit )
+    :param replica_positions: Positions array for the replica exchange data for which we will write PDB files
+    :type replica_positions: `Quantity() <http://docs.openmm.org/development/api-python/generated/simtk.unit.quantity.Quantity.html>`_ ( np.array( [n_replicas,cgmodel.num_beads,3] ), simtk.unit )
 
-        :param replica_energies: List of dimension num_replicas X simulation_steps, which gives the energies for all replicas at all simulation steps 
-        :type replica_energies: List( List( float * simtk.unit.energy for simulation_steps ) for num_replicas )
+    :param replica_energies: List of dimension num_replicas X simulation_steps, which gives the energies for all replicas at all simulation steps 
+    :type replica_energies: List( List( float * simtk.unit.energy for simulation_steps ) for num_replicas )
 
-        :param temperature_list: List of temperatures for the simulation data.
-        :type temperature_list: List( float * simtk.unit.temperature )
+    :param temperature_list: List of temperatures for the simulation data.
+    :type temperature_list: List( float * simtk.unit.temperature )
 
-        :returns:
-           - configurations ( List( `Quantity() <http://docs.openmm.org/development/api-python/generated/simtk.unit.quantity.Quantity.html>`_ (n_decorrelated_samples,cgmodel.num_beads,3), simtk.unit ) ) - A list of decorrelated samples
-           - energies ( List( `Quantity() <http://docs.openmm.org/development/api-python/generated/simtk.unit.quantity.Quantity.html>`_ ) ) - The energies for the decorrelated samples (configurations)
+    :returns:
+       - configurations ( List( `Quantity() <http://docs.openmm.org/development/api-python/generated/simtk.unit.quantity.Quantity.html>`_ (n_decorrelated_samples,cgmodel.num_beads,3), simtk.unit ) ) - A list of decorrelated samples
+       - energies ( List( `Quantity() <http://docs.openmm.org/development/api-python/generated/simtk.unit.quantity.Quantity.html>`_ ) ) - The energies for the decorrelated samples (configurations)
 
         """
     all_poses = []
@@ -67,7 +67,7 @@ def get_decorrelated_samples(replica_positions, replica_energies, temperature_li
         [t0, g, Neff_max] = timeseries.detectEquilibration(energies)
         energies_equil = energies[t0:]
         poses_equil = replica_positions[replica_index][t0:]
-        indices = timeseries.subsampleCorrelatedData(energies_equil)
+        indices = timeseries.subsample_correlated_data(energies_equil)
         for index in indices:
             all_energies.append(energies_equil[index])
             all_poses.append(poses_equil[index])
@@ -79,90 +79,76 @@ def get_decorrelated_samples(replica_positions, replica_energies, temperature_li
 
 def get_entropy_differences(mbar):
     """
-        Given an `MBAR <https://pymbar.readthedocs.io/en/latest/mbar.html>`_ class object, this function computes the entropy differences for the states defined within.
+    Given an `MBAR <https://pymbar.readthedocs.io/en/latest/mbar.html>`_ class object, this function computes the entropy differences for the states defined within.
 
-        :param mbar: An MBAR() class object (from the 'pymbar' package)
-        :type mbar: `MBAR <https://pymbar.readthedocs.io/en/latest/mbar.html>`_ class object
+    :param mbar: An MBAR() class object (from the 'pymbar' package)
+    :type mbar: `MBAR <https://pymbar.readthedocs.io/en/latest/mbar.html>`_ class object
 
-        :returns:
-          - Delta_s ( np.array( n_mbar_states x n_thermo_states ) - Entropy differences for the thermodynamic states in 'mbar'
-          - dDelta_s ( np.array( n_mbar_states x n_thermo_states ) - Uncertainty in the entropy differences for the thermodynamic states in 'mbar'
+    :returns:
+      - Delta_s ( np.array( n_mbar_states x n_thermo_states ) - Entropy differences for the thermodynamic states in 'mbar'
+      - dDelta_s ( np.array( n_mbar_states x n_thermo_states ) - Uncertainty in the entropy differences for the thermodynamic states in 'mbar'
 
-        """
-    results = mbar.computeEntropyAndEnthalpy()
-    results = {
-        "Delta_f": results[0],
-        "dDelta_f": results[1],
-        "Delta_u": results[2],
-        "dDelta_u": results[3],
-        "Delta_s": results[4],
-        "dDelta_s": results[5],
-    }
+    """
+    results = mbar.compute_entropy_and_enthalpy()
     Delta_s = results["Delta_s"]
     dDelta_s = results["dDelta_s"]
+    
     return (Delta_s, dDelta_s)
 
 
 def get_enthalpy_differences(mbar):
     """
-        Given an `MBAR <https://pymbar.readthedocs.io/en/latest/mbar.html>`_ class object, this function computes the enthalpy differences for the states defined within.
+    Given an `MBAR <https://pymbar.readthedocs.io/en/latest/mbar.html>`_ class object, this function computes the enthalpy differences for the states defined within.
 
-        :param mbar: An MBAR() class object (from the 'pymbar' package)
-        :type mbar: `MBAR <https://pymbar.readthedocs.io/en/latest/mbar.html>`_ class object
+    :param mbar: An MBAR() class object (from the 'pymbar' package)
+    :type mbar: `MBAR <https://pymbar.readthedocs.io/en/latest/mbar.html>`_ class object
 
-        :returns:
-          - Delta_u ( np.array( n_mbar_states x n_thermo_states ) - Enthalpy differences for the thermodynamic states in 'mbar'
-          - dDelta_u ( np.array( n_mbar_states x n_thermo_states ) - Uncertainty in the enthalpy differences for the thermodynamic states in 'mbar'
+    :returns:
+      - Delta_u ( np.array( n_mbar_states x n_thermo_states ) - Enthalpy differences for the thermodynamic states in 'mbar'
+      - dDelta_u ( np.array( n_mbar_states x n_thermo_states ) - Uncertainty in the enthalpy differences for the thermodynamic states in 'mbar'
 
-        """
-    results = mbar.computeEntropyAndEnthalpy()
-    results = {
-        "Delta_f": results[0],
-        "dDelta_f": results[1],
-        "Delta_u": results[2],
-        "dDelta_u": results[3],
-        "Delta_s": results[4],
-        "dDelta_s": results[5],
-    }
+    """
+    results = mbar.compute_entropy_and_enthalpy()
     Delta_u = results["Delta_u"]
     dDelta_u = results["dDelta_u"]
+    
     return (Delta_u, dDelta_u)
 
 
 def get_free_energy_differences(mbar):
     """
-        Given an `MBAR <https://pymbar.readthedocs.io/en/latest/mbar.html>`_ class object, this function computes the free energy differences for the states defined within.
+    Given an `MBAR <https://pymbar.readthedocs.io/en/latest/mbar.html>`_ class object, this function computes the free energy differences for the states defined within.
 
-        :param mbar: An MBAR() class object (from the 'pymbar' package)
-        :type mbar: `MBAR <https://pymbar.readthedocs.io/en/latest/mbar.html>`_ class object
+    :param mbar: An MBAR() class object (from the 'pymbar' package)
+    :type mbar: `MBAR <https://pymbar.readthedocs.io/en/latest/mbar.html>`_ class object
 
-        :returns:
-          - df_ij ( np.array( n_mbar_states x n_thermo_states ) - Free energy differences for the thermodynamic states in 'mbar'
-          - ddf_ij ( np.array( n_mbar_states x n_thermo_states ) - Uncertainty in the free energy differences for the thermodynamic states in 'mbar'
+    :returns:
+      - df_ij ( np.array( n_mbar_states x n_thermo_states ) - Free energy differences for the thermodynamic states in 'mbar'
+      - ddf_ij ( np.array( n_mbar_states x n_thermo_states ) - Uncertainty in the free energy differences for the thermodynamic states in 'mbar'
 
-        """
-    results = mbar.getFreeEnergyDifferences()
-    results = {"Delta_f": results[0], "dDelta_f": results[1]}
+    """
+    results = mbar.compute_entropy_and_enthalpy()
     df_ij = results["Delta_f"]
     ddf_ij = results["dDelta_f"]
+    
     return (df_ij, ddf_ij)
 
 
 def get_temperature_list(min_temp, max_temp, num_replicas):
     """
-        Given the parameters to define a temperature range as input, this function uses logarithmic spacing to generate a list of intermediate temperatures.
+    Given the parameters to define a temperature range as input, this function uses logarithmic spacing to generate a list of intermediate temperatures.
 
-        :param min_temp: The minimum temperature in the temperature list.
-        :type min_temp: `Quantity() <http://docs.openmm.org/development/api-python/generated/simtk.unit.quantity.Quantity.html>`_
+    :param min_temp: The minimum temperature in the temperature list.
+    :type min_temp: `Quantity() <http://docs.openmm.org/development/api-python/generated/simtk.unit.quantity.Quantity.html>`_
 
-        :param max_temp: The maximum temperature in the temperature list.
-        :type max_temp: `Quantity() <http://docs.openmm.org/development/api-python/generated/simtk.unit.quantity.Quantity.html>`_
+    :param max_temp: The maximum temperature in the temperature list.
+    :type max_temp: `Quantity() <http://docs.openmm.org/development/api-python/generated/simtk.unit.quantity.Quantity.html>`_
 
-        :param num_replicas: The number of temperatures in the list.
-        :type num_replicas: int
+    :param num_replicas: The number of temperatures in the list.
+    :type num_replicas: int
 
-        :returns:
-           - temperature_list ( 1D numpy array ( float * simtk.unit.temperature ) ) - List of temperatures
+    :returns:
+       - temperature_list ( 1D numpy array ( float * simtk.unit.temperature ) ) - List of temperatures
 
     """
     
@@ -376,35 +362,33 @@ def get_intermediate_temperatures(T_from_file, NumIntermediates):
 
 def get_mbar_expectation(E_kln, temperature_list, NumIntermediates, output=None, mbar=None):
     """
-        Given a properly-formatted matrix of energies with associated temperatures this function reweights with MBAR (if 'mbar'=None), and can also compute the expectation value for any property of interest.
+    Given a properly-formatted matrix of energies with associated temperatures this function reweights with MBAR (if 'mbar'=None), and can also compute the expectation value for any property of interest.
 
-        .. warning:: This function accepts an input matrix thtat has either 'E_kln' or 'E_kn' format, but always provides an 'E_kn'-formatted matrix in return.
+    .. warning:: This function accepts an input matrix thtat has either 'E_kln' or 'E_kn' format, but always provides an 'E_kn'-formatted matrix in return.
 
-        :param E_kln: A matrix of energies or samples for a property that we would like to use to make predictions with MBAR.
-        :type E_kln: List( List( float * simtk.unit.energy for simulation_steps ) for num_replicas ) OR List( List( List( float * simtk.unit.energy for simulation_steps ) for num_replicas ) for num_replicas )
+    :param E_kln: A matrix of energies or samples for a property that we would like to use to make predictions with MBAR.
+    :type E_kln: List( List( float * simtk.unit.energy for simulation_steps ) for num_replicas ) OR List( List( List( float * simtk.unit.energy for simulation_steps ) for num_replicas ) for num_replicas )
 
-        :param temperature_list: List of temperatures for the simulation data.
-        :type temperature_list: List( float * simtk.unit.temperature )
+    :param temperature_list: List of temperatures for the simulation data.
+    :type temperature_list: List( float * simtk.unit.temperature )
 
-        :param NumIntermediates: The number of states to insert between existing states in 'T_from_file'
-        :type NumIntermediates: int
+    :param NumIntermediates: The number of states to insert between existing states in 'T_from_file'
+    :type NumIntermediates: int
 
-        :param output: The 'output' option to use when calling MBAR, default = 'differences'
-        :type output: str
+    :param output: The 'output' option to use when calling MBAR, default = 'differences'
+    :type output: str
 
-        :param mbar: An MBAR() class object (from the 'pymbar' package), default = None
-        :type mbar: `MBAR <https://pymbar.readthedocs.io/en/latest/mbar.html>`_ class object
+    :param mbar: An MBAR() class object (from the 'pymbar' package), default = None
+    :type mbar: `MBAR <https://pymbar.readthedocs.io/en/latest/mbar.html>`_ class object
 
-        :returns:
-          - mbar ( `MBAR <https://pymbar.readthedocs.io/en/latest/mbar.html>`_ ) - An MBAR() class object (from the 'pymbar' package)          
-         - E_kn ( List( List( float * simtk.unit.energy for num_samples ) for num_replicas ) ) - A matrix of energies or samples for a property that we would like to use to make predictions with MBAR.
-         - result ( List( List( float for num_samples ) for num_replicas ) - The MBAR expectation value for the energies and/or other samples that were provided.
-         - dresult ( List( List( float for num_samples ) for num_replicas ) - The MBAR expectation value for the energies and/or other samples that were provided.
-         - Temp_k ( List( float * simtk.unit.temperature ) ) - A new list of temperatures that includes the inserted intermediates.
+    :returns:
+      - mbar ( `MBAR <https://pymbar.readthedocs.io/en/latest/mbar.html>`_ ) - An MBAR() class object (from the 'pymbar' package)          
+     - E_kn ( List( List( float * simtk.unit.energy for num_samples ) for num_replicas ) ) - A matrix of energies or samples for a property that we would like to use to make predictions with MBAR.
+     - result ( List( List( float for num_samples ) for num_replicas ) - The MBAR expectation value for the energies and/or other samples that were provided.
+     - dresult ( List( List( float for num_samples ) for num_replicas ) - The MBAR expectation value for the energies and/or other samples that were provided.
+     - Temp_k ( List( float * simtk.unit.temperature ) ) - A new list of temperatures that includes the inserted intermediates.
 
-
-
-        """
+    """
 
     if mbar == None:
         NumTemps = len(temperature_list)  # Last TEMP # + 1 (start counting at 1)
@@ -416,9 +400,9 @@ def get_mbar_expectation(E_kln, temperature_list, NumIntermediates, output=None,
 
         g = np.zeros(originalK, np.float64)
         for k in range(originalK):  # subsample the energies
-            g[k] = pymbar.timeseries.statisticalInefficiency(E_from_file[k][k])
+            g[k] = pymbar.timeseries.statistical_inefficiency(E_from_file[k][k])
             indices = np.array(
-                pymbar.timeseries.subsampleCorrelatedData(E_from_file[k][k], g=g[k])
+                pymbar.timeseries.subsample_correlated_data(E_from_file[k][k], g=g[k])
             )  # indices of uncorrelated samples
             N_k[k] = len(indices)
             E_from_file[k, k, 0 : N_k[k]] = E_from_file[k, k, indices]
@@ -490,12 +474,10 @@ def get_mbar_expectation(E_kln, temperature_list, NumIntermediates, output=None,
 
     if output != None:
         results = mbar.computeExpectations(E_kn, output="differences", state_dependent=True)
-        results = {"mu": results[0], "sigma": results[1]}
         result = results["mu"]
         dresult = results["sigma"]
     else:
         results = mbar.computeExpectations(E_kn, state_dependent=True)
-        results = {"mu": results[0], "sigma": results[1]}
         result = results["mu"]
         dresult = results["sigma"]
 

--- a/cg_openmm/parameters/secondary_structure.py
+++ b/cg_openmm/parameters/secondary_structure.py
@@ -247,7 +247,7 @@ def expectations_fraction_contacts(fraction_native_contacts, frame_begin=0, samp
     :param frame_begin: index of first frame defining the range of samples to use as a production period (default=0)
     :type frame_begin: int
 
-    :param sample_spacing: spacing of uncorrelated data points, for example determined from pymbar timeseries subsampleCorrelatedData (default=1)
+    :param sample_spacing: spacing of uncorrelated data points, for example determined from pymbar timeseries subsample_correlated_data (default=1)
     :type sample_spacing: int       
     
     :param output_data: Path to the output data for a NetCDF-formatted file containing replica exchange simulation data (default="output/output.nc")                                                                                                  
@@ -352,12 +352,10 @@ def expectations_fraction_contacts(fraction_native_contacts, frame_begin=0, samp
                 ti += 1
                 N_k[k] = n_samples//len(temps)  # these are the states that have samples
 
-    # call MBAR to find weights at all states, sampled and unsampled
-    solver_protocol = {"method":"L-BFGS-B"}
-    
+    # call MBAR to find weights at all states, sampled and unsampled 
     mbarT = pymbar.MBAR(
-        unsampled_state_energies,N_k,verbose=False,relative_tolerance=1e-12,
-        maximum_iterations=10000,solver_protocol=(solver_protocol,),
+        unsampled_state_energies,N_k,relative_tolerance=1e-12,
+        solver_protocol='robust', maximum_iterations=1000000,
         )
         
     # Now we have the weights at all temperatures, so we can
@@ -367,9 +365,9 @@ def expectations_fraction_contacts(fraction_native_contacts, frame_begin=0, samp
     Q = np.reshape(fraction_native_contacts,np.size(fraction_native_contacts), order='F')
             
     # calculate the expectation of Q at each unsampled states         
-    results = mbarT.computeExpectations(Q)  # compute expectations of Q at all points
-    Q_expect = results[0]
-    dQ_expect = results[1]
+    results = mbarT.compute_expectations(Q)  # compute expectations of Q at all points
+    Q_expect = results['mu']
+    dQ_expect = results['sigma']
 
     # return the results in a dictionary (better than in a list)
     return_results = dict()
@@ -411,7 +409,7 @@ def fraction_native_contacts(
     :param native_contact_tol: Tolerance factor beyond the native distance for determining whether a pair of particles is 'native' (in multiples of native distance) (default=1.3)
     :type native_contact_tol: float
     
-    :param subsample: option to use pymbar subsampleCorrelatedData to detect and return the interval between uncorrelated data points (default=True)
+    :param subsample: option to use pymbar subsample_correlated_data to detect and return the interval between uncorrelated data points (default=True)
     :type subsample: Boolean
     
     :param homopolymer_sym: if there is end-to-end symmetry, scan forwards and backwards sequences for highest Q (default=False)
@@ -516,7 +514,7 @@ def fraction_native_contacts(
         g = np.zeros(n_replicas)
         subsample_indices = {}
         for rep in range(n_replicas):
-            subsample_indices[rep] = timeseries.subsampleCorrelatedData(
+            subsample_indices[rep] = timeseries.subsample_correlated_data(
                 Q[:,rep],
                 conservative=True,
             )
@@ -566,7 +564,7 @@ def fraction_native_contacts_preloaded(
     :param native_contact_tol: Tolerance factor beyond the native distance for determining whether a pair of particles is 'native' (in multiples of native distance) (default=1.3)
     :type native_contact_tol: float
     
-    :param subsample: option to use pymbar subsampleCorrelatedData to detect and return the interval between uncorrelated data points (default=True)
+    :param subsample: option to use pymbar subsample_correlated_data to detect and return the interval between uncorrelated data points (default=True)
     :type subsample: Boolean
     
     :param homopolymer_sym: if there is end-to-end symmetry, scan forwards and backwards sequences for highest Q (default=False)
@@ -651,7 +649,7 @@ def fraction_native_contacts_preloaded(
         g = np.zeros(n_replicas)
         subsample_indices = {}
         for rep in range(n_replicas):
-            subsample_indices[rep] = timeseries.subsampleCorrelatedData(
+            subsample_indices[rep] = timeseries.subsample_correlated_data(
                 Q[:,rep],
                 conservative=True,
             )
@@ -697,7 +695,7 @@ def optimize_Q_cut(
     :param frame_begin: index of first frame defining the range of samples to use as a production period (default=0)
     :type frame_begin: int
 
-    :param frame_stride: spacing of uncorrelated data points, for example determined from pymbar timeseries subsampleCorrelatedData (default=1)
+    :param frame_stride: spacing of uncorrelated data points, for example determined from pymbar timeseries subsample_correlated_data (default=1)
     :type frame_stride: int
     
     :param plotfile: Path to output file for plotting results (default='native_contacts_opt_2d.pdf')
@@ -941,7 +939,7 @@ def optimize_Q_cut_1d(
     :param frame_begin: index of first frame defining the range of samples to use as a production period (default=0)
     :type frame_begin: int
 
-    :param frame_stride: spacing of uncorrelated data points, for example determined from pymbar timeseries subsampleCorrelatedData (default=1)
+    :param frame_stride: spacing of uncorrelated data points, for example determined from pymbar timeseries subsample_correlated_data (default=1)
     :type frame_stride: int
     
     :param native_contact_tol: Tolerance factor beyond the native distance for determining whether a pair of particles is 'native' (in multiples of native distance) (default=1.3)
@@ -1171,7 +1169,7 @@ def bootstrap_native_contacts_expectation(
     :param frame_begin: Frame at which to start native contacts analysis (default=0)
     :type frame_begin: int
     
-    :param sample_spacing: spacing of uncorrelated data points, for example determined from pymbar timeseries subsampleCorrelatedData (default=1)
+    :param sample_spacing: spacing of uncorrelated data points, for example determined from pymbar timeseries subsample_correlated_data (default=1)
     :type sample_spacing: int
     
     :param native_contact_tol: Tolerance factor beyond the native distance for determining whether a pair of particles is 'native' (in multiples of native distance) (default=1.3)
@@ -1463,7 +1461,7 @@ def optimize_Q_tol_helix(
     :param frame_begin: index of first frame defining the range of samples to use as a production period (default=0)
     :type frame_begin: int
 
-    :param frame_stride: spacing of uncorrelated data points, for example determined from pymbar timeseries subsampleCorrelatedData (default=1)
+    :param frame_stride: spacing of uncorrelated data points, for example determined from pymbar timeseries subsample_correlated_data (default=1)
     :type frame_stride: int 
     
     :param backbone_type_name: type name(s) in cgmodel which corresponds to the particles forming the helical backbone (default='bb')

--- a/cg_openmm/simulation/rep_exch.py
+++ b/cg_openmm/simulation/rep_exch.py
@@ -798,6 +798,7 @@ def run_replica_exchange(
         mcmc_moves=move,
         number_of_iterations=exchange_attempts,
         replica_mixing_scheme='swap-neighbors',
+        online_analysis_interval=None,
     )
 
     if os.path.exists(output_data):
@@ -812,6 +813,9 @@ def run_replica_exchange(
     print("Running OpenMM replica exchange simulation...")
     print(f"Time step: {simulation_time_step}")
     print(f"Iterations: {exchange_attempts}",flush=True)
+    
+    simulation.run()
+    
     try:
         simulation.run()
     except BaseException:

--- a/cg_openmm/simulation/rep_exch.py
+++ b/cg_openmm/simulation/rep_exch.py
@@ -401,10 +401,10 @@ def process_replica_exchange_data(
     :param write_data_file: Option to write a text data file containing the state_energies array (default=True)
     :type write_data_file: Boolean
     
-    :param plot_production_only: Option to plot only the production region, as determined from pymbar detectEquilibration (default=False)
+    :param plot_production_only: Option to plot only the production region, as determined from pymbar detect_equilibration (default=False)
     :type plot_production_only: Boolean    
 
-    :param equil_nskip: skip this number of frames to sparsify the energy timeseries for pymbar detectEquilibration (default=1) - this is used only when frame_begin=0 and the trajectory has less than 40000 frames.
+    :param equil_nskip: skip this number of frames to sparsify the energy timeseries for pymbar detect_equilibration (default=1) - this is used only when frame_begin=0 and the trajectory has less than 40000 frames.
     :type equil_nskip: Boolean
     
     :param frame_begin: analyze starting from this frame, discarding all prior as equilibration period (default=0)
@@ -416,7 +416,7 @@ def process_replica_exchange_data(
     :returns:
         - replica_energies ( `Quantity() <http://docs.openmm.org/development/api-python/generated/simtk.unit.quantity.Quantity.html>`_ ( np.float( [number_replicas,number_simulation_steps] ), simtk.unit ) ) - The potential energies for all replicas at all (printed) time steps
         - replica_state_indices ( np.int64( [number_replicas,number_simulation_steps] ), simtk.unit ) - The thermodynamic state assignments for all replicas at all (printed) time steps
-        - production_start ( int - The frame at which the production region begins for all replicas, as determined from pymbar detectEquilibration
+        - production_start ( int - The frame at which the production region begins for all replicas, as determined from pymbar detect_equilibration
         - sample_spacing ( int - The number of frames between uncorrelated state energies, estimated using heuristic algorithm )
         - n_transit ( np.float( [number_replicas] ) ) - Number of half-transitions between state 0 and n for each replica
         - mixing_stats ( tuple ( np.float( [number_replicas x number_replicas] ) , np.float( [ number_replicas ] ) , float( statistical inefficiency ) ) ) - transition matrix, corresponding eigenvalues, and statistical inefficiency
@@ -515,7 +515,7 @@ def process_replica_exchange_data(
     subsample_indices = {}
     
     # If sufficiently large, discard the first 20000 frames as equilibration period and use 
-    # subsampleCorrelatedData to get the energy decorrelation time.
+    # subsample_correlated_data to get the energy decorrelation time.
     if total_steps >= 40000 or frame_begin > 0:
         if frame_begin > 0:
             # If specified, use frame_begin as the start of the production region
@@ -525,16 +525,16 @@ def process_replica_exchange_data(
             production_start=20000
             
         for state in range(n_replicas):
-            subsample_indices[state] = timeseries.subsampleCorrelatedData(
+            subsample_indices[state] = timeseries.subsample_correlated_data(
                 state_energies[state][production_start:],
                 conservative=True,
             )
             g[state] = subsample_indices[state][1]-subsample_indices[state][0]
     
     else:
-        # For small trajectories, use detectEquilibration
+        # For small trajectories, use detect_equilibration
         for state in range(n_replicas):
-            t0[state], g[state], Neff_max = timeseries.detectEquilibration(state_energies[state], nskip=equil_nskip)  
+            t0[state], g[state], Neff_max = timeseries.detect_equilibration(state_energies[state], nskip=equil_nskip)  
 
             # Choose the latest equil timestep to apply to all states    
             production_start = int(np.max(t0))

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -13,7 +13,7 @@ dependencies:
   - physical_validation
   - pickleshare
   - pip
-  - pymbar=3
+  - pymbar=4
   - pytest
   - pytest-cov
   - python

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -9,7 +9,6 @@ dependencies:
   - mpi4py
   - numpy
   - openmm
-  - openmmtools=0.21.1
   - physical_validation
   - pickleshare
   - pip
@@ -26,4 +25,5 @@ dependencies:
   - pip:
     - codecov
     - git+https://github.com/shirtsgroup/analyze_foldamers.git
+    - git+https://github.com/cwalker7/openmmtools.git@openmmtools_0_21_2_pymbar_4
 


### PR DESCRIPTION
## Description
Updates mbar functionality to work with pymbar version 4.0. A number of changes were made according to this guide:
[https://pymbar.readthedocs.io/en/master/moving_from_pymbar3.html](https://pymbar.readthedocs.io/en/master/moving_from_pymbar3.html)

MBAR solvers are now more reliable than version 3 - in all cases, I set the algorithm to 'robust' with maximum iterations of 1E6. 

## TODOS
- [ ] Some new segfaults popping up with process_replica_exchange tests. Figure out if this is related to changes in the timeseries module

## Status
- [ ] Ready to go