### PR TITLE
Make random builder independent of monomer bond_list order

### DIFF
--- a/cg_openmm/tests/test_random_builder.py
+++ b/cg_openmm/tests/test_random_builder.py
@@ -125,3 +125,65 @@ def test_random_builder(tmpdir):
     positions = PDBFile(filename).getPositions()
     
     assert len(positions)==10
+
+@pytest.mark.parametrize(
+    "monomer_bond_list",
+    [
+        [[0, 1], [0, 2], [1, 3]],  # sorted (previously working)
+        [[0, 1], [1, 3], [0, 2]],  # unsorted (issue #153)
+        [[1, 3], [0, 2], [0, 1]],  # fully shuffled
+    ],
+)
+def test_random_builder_bond_list_order(tmpdir, monomer_bond_list):
+    """The random builder should not depend on the order of a monomer's bond_list
+    (issue #153). Uses a 1-backbone / 3-sidechain monomer with both 2-bead and
+    1-bead sidechain connections to the same backbone bead."""
+
+    bond_length = 1.5 * unit.angstrom
+    bond_lengths = {
+        "bb_bb_bond_length": bond_length,
+        "bb_sc_bond_length": bond_length,
+        "sc_sc_bond_length": bond_length,
+    }
+    bond_force_constant = 1000 * unit.kilojoule_per_mole / unit.nanometer / unit.nanometer
+    bond_force_constants = {
+        "bb_bb_bond_force_constant": bond_force_constant,
+        "bb_sc_bond_force_constant": bond_force_constant,
+        "sc_sc_bond_force_constant": bond_force_constant,
+    }
+
+    mass = 100.0 * unit.amu
+    sigma = 1.5 * bond_length / (2.0 ** (1.0 / 6.0))
+    epsilon = 0.5 * unit.kilojoule_per_mole
+
+    bb = {"particle_type_name": "bb", "sigma": sigma, "epsilon": epsilon, "mass": mass}
+    sc = {"particle_type_name": "sc", "sigma": sigma, "epsilon": epsilon, "mass": mass}
+
+    A = {
+        "monomer_name": "A",
+        "particle_sequence": [bb, sc, sc, sc],
+        "bond_list": monomer_bond_list,
+        "start": 0,
+        "end": 0,
+    }
+
+    cgmodel = CGModel(
+        particle_type_list=[bb, sc],
+        bond_lengths=bond_lengths,
+        bond_force_constants=bond_force_constants,
+        include_nonbonded_forces=True,
+        include_bond_forces=True,
+        include_bond_angle_forces=False,
+        include_torsion_forces=False,
+        sequence=3 * [A],
+        constrain_bonds=False,
+        random_positions=True,
+        monomer_types=[A],
+    )
+
+    output_directory = tmpdir.mkdir("output")
+    filename = f"{output_directory}/3mer_1b3s_builder_test.pdb"
+    write_pdbfile_without_topology(cgmodel, filename)
+    positions = PDBFile(filename).getPositions()
+
+    assert len(positions) == 12

--- a/cg_openmm/utilities/random_builder.py
+++ b/cg_openmm/utilities/random_builder.py
@@ -722,15 +722,29 @@ def get_random_positions(
                     completed_list.append(bead_index)
                     bead_index = bead_index + 1
                 else:
-                    # place the monomers involved in this bond
+                    # place the beads involved in these bonds.
+                    # Beads must be placed in ascending index order, because each new
+                    # bead's coordinates are inserted at row bead_index of the positions
+                    # array. A bond is ready to be placed only when one of its ends is
+                    # the next bead to place (bead_index) and its other end has already
+                    # been placed. Bonds that are not ready yet are skipped and picked
+                    # up on a later sweep, so the monomer bond_list may be given in any
+                    # order (see issue #153).
+                    placed_in_sweep = False
                     for bond_index in range(len(monomer_bond_list)):
                         bond = monomer_bond_list[bond_index]
                         if bond[0] in completed_list and bond[1] in completed_list:
                             continue  # if bond atoms in completed list, go in to the next bond
+                        if bond[0] == bead_index and bond[1] < bead_index:
+                            parent_bead, new_bead = bond[1], bond[0]
+                        elif bond[1] == bead_index and bond[0] < bead_index:
+                            parent_bead, new_bead = bond[0], bond[1]
+                        else:
+                            continue  # this bond cannot be placed yet
                         # place the atoms on a pseudogrid
                         if lattice_style:
                             trial_positions, placement = assign_position_lattice_style(
-                                cgmodel, stored_positions, distance_cutoff, bond[0], bond[1]
+                                cgmodel, stored_positions, distance_cutoff, parent_bead, new_bead
                             )
                         else:
                             # this choice not working now
@@ -738,18 +752,30 @@ def get_random_positions(
                                 stored_positions,
                                 get_bond_length(bond),
                                 distance_cutoff,
-                                bond[1],
-                                bond[0],
+                                parent_bead,
+                                new_bead,
                             )
 
                         if placement:  # if we successfuly placed this atom, move to the next one.
                             stored_positions = trial_positions
-                            completed_list.append(bead_index)
+                            completed_list.append(new_bead)
                             bead_index = bead_index + 1
+                            placed_in_sweep = True
                         else:
                             # we tried 6 directions, and we couldn't place it. Trapped!
                             monomer_trapped = True
                             break
+
+                    if not placed_in_sweep and not monomer_trapped:
+                        # No bond could place the next bead, so another sweep will not
+                        # make progress; the monomer's bond graph cannot be built up
+                        # one bead at a time in index order.
+                        raise ValueError(
+                            f"Cannot determine a placement order for the beads of monomer "
+                            f"{monomer_index} from its bond list. Check that every bead in "
+                            f"the monomer is connected (directly or through lower-indexed "
+                            f"beads) to the start of the monomer."
+                        )
 
             if monomer_trapped:
                 # there is no way to go - start over with the first monomer.


### PR DESCRIPTION
The bead-placement loop in get_random_positions assumed each bond's second index was the next bead to place and its first index an already-placed parent, so it only worked when the monomer bond_list happened to be sorted in placement order. With an unsorted list (e.g. [[0,1],[1,3],[0,2]] for a 1-backbone/3-sidechain monomer) it tried to insert a bead at a row beyond the current positions array, raising IndexError: index 3 is out of bounds for axis 0 with size 2.

A bond is now placed only when one end is the next bead index and the other end is already placed (in either orientation); bonds that are not ready are picked up on a later sweep, and a clear ValueError is raised if no ordering exists. Adds a parametrized regression test covering sorted, unsorted, and fully shuffled bond lists.

Fixes #153 